### PR TITLE
Removed requirement for prefixing json input keys and result keys with test name 

### DIFF
--- a/src/error_body.rs
+++ b/src/error_body.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// `title` is a brief summary of the error
 /// `status` is the http status code
 /// `detail` is a more detailed explanation of the error
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ErrorBody<'a> {
     pub title: &'a str,
     pub status: u16,

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -339,7 +339,7 @@ fn fill_results(
     // Loop through template_results, check for each of the keys in outputs, and add them to list to write
     for template_result in template_results {
         // Check outputs for this result
-        match outputs.get(&*template_result.result_key) {
+        match outputs.get(&format!("merged_workflow.{}", template_result.result_key)) {
             // If we found it, add it to the list of results to write tot he DB
             Some(output) => {
                 let output = match output.as_str() {
@@ -475,8 +475,8 @@ mod tests {
         let test_run = insert_test_run_with_test_id(&conn, test_test.test_id.clone());
         // Create results map
         let results_map = json!({
-            "TestKey": "TestVal",
-            "UnimportantKey": "Who Cares?"
+            "merged_workflow.TestKey": "TestVal",
+            "merged_workflow.UnimportantKey": "Who Cares?"
         });
         let results_map = results_map.as_object().unwrap().to_owned();
         // Fill results
@@ -507,8 +507,8 @@ mod tests {
           "id": "53709600-d114-4194-a7f7-9e41211ca2ce",
           "status": "Succeeded",
           "outputs": {
-            "TestKey": "TestVal",
-            "UnimportantKey": "Who Cares?"
+            "merged_workflow.TestKey": "TestVal",
+            "merged_workflow.UnimportantKey": "Who Cares?"
           },
           "end": "2020-12-31T11:11:11.0000Z"
         });

--- a/src/routes/run.rs
+++ b/src/routes/run.rs
@@ -17,7 +17,7 @@ use actix_web::{client::Client, error::BlockingError, web, HttpRequest, HttpResp
 use chrono::{NaiveDateTime, Utc};
 use log::error;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Value, map::Map};
 use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -393,27 +393,72 @@ async fn run_for_test(
     web::Json(run_inputs): web::Json<NewRunIncomplete>,
     pool: web::Data<db::DbPool>,
     client: web::Data<Client>,
-) -> impl Responder {
+) -> Result<HttpResponse, actix_web::Error> {
+    // Try to get run by name to see if a run with that name already exists
+    if let Some(name) = &run_inputs.name {
+        let run_name_query = RunQuery {
+            pipeline_id: None,
+            template_id: None,
+            test_id: None,
+            name: Some(name.clone()),
+            status: None,
+            test_input: None,
+            eval_input: None,
+            cromwell_job_id: None,
+            created_before: None,
+            created_after: None,
+            created_by: None,
+            finished_before: None,
+            finished_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+        let conn = pool
+            .get()
+            .expect("Failed to get DB connection from pool");
+        match web::block(move || RunData::find(&conn, run_name_query)).await {
+            Ok(run_data) => {
+                // If we got a result, return an error message to the user
+                if run_data.len() > 0 {
+                    error!("Found existing run with name: {}", name);
+                    return Ok(HttpResponse::BadRequest().json(ErrorBody {
+                        title: "Run with specified name already exists",
+                        status: 400,
+                        detail: "If a custom run name is specified, it must be unique.",
+                    }))
+                }
+            },
+            Err(e) => {
+                error!("{}", e);
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody {
+                    title: "Server error",
+                    status: 500,
+                    detail: "Error while attempting to retrieve template data",
+                }));
+            }
+        };
+    }
     // Parse test id into UUID
     let test_id = match Uuid::parse_str(&*id) {
         Ok(id) => id,
         Err(e) => {
             error!("{}", e);
             // If it doesn't parse successfully, return an error to the user
-            return HttpResponse::BadRequest().json(ErrorBody {
+            return Ok(HttpResponse::BadRequest().json(ErrorBody {
                 title: "ID formatted incorrectly",
                 status: 400,
                 detail: "ID must be formatted as a Uuid",
-            });
+            }));
         }
     };
     // Retrieve test for id or return error
-    let conn = pool.get().expect("Failed to get DB connection from pool");
+    let conn = pool.clone().get().expect("Failed to get DB connection from pool");
     let test = match web::block(move || TestData::find_by_id(&conn, test_id)).await {
         Ok(test_data) => test_data,
         Err(e) => {
             error!("{}", e);
-            return match e {
+            return Ok(match e {
                 // If no test is found, return a 404
                 BlockingError::Error(diesel::NotFound) => {
                     HttpResponse::NotFound().json(ErrorBody {
@@ -428,7 +473,7 @@ async fn run_for_test(
                     status: 500,
                     detail: "Error while attempting to retrieve test data",
                 }),
-            };
+            });
         }
     };
 
@@ -458,7 +503,7 @@ async fn run_for_test(
         Ok(template_data) => template_data,
         Err(e) => {
             error!("{}", e);
-            return match e {
+            return Ok(match e {
                 // If no test is found, return a 404
                 BlockingError::Error(diesel::NotFound) => {
                     HttpResponse::NotFound().json(ErrorBody {
@@ -473,7 +518,7 @@ async fn run_for_test(
                     status: 500,
                     detail: "Error while attempting to retrieve template data",
                 }),
-            };
+            });
         }
     };
 
@@ -483,14 +528,14 @@ async fn run_for_test(
             Ok(wdl) => wdl,
             Err(e) => {
                 error!("{}", e);
-                return HttpResponse::InternalServerError().json(ErrorBody {
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                     title: "Server error",
                     status: 500,
                     detail: &format!(
                         "Error while attempting to retrieve test WDL from {}",
                         template.test_wdl
                     ),
-                });
+                }));
             }
         };
 
@@ -499,14 +544,14 @@ async fn run_for_test(
             Ok(wdl) => wdl,
             Err(e) => {
                 error!("{}", e);
-                return HttpResponse::InternalServerError().json(ErrorBody {
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                     title: "Server error",
                     status: 500,
                     detail: &format!(
                         "Error while attempting to retrieve eval WDL from {}",
                         template.eval_wdl
                     ),
-                });
+                }));
             }
         };
 
@@ -516,16 +561,15 @@ async fn run_for_test(
         &template.test_wdl,
         &eval_wdl,
         &template.eval_wdl,
-        &test.name,
     ) {
         Ok(wdl) => wdl,
         Err(e) => {
             error!("{}", e);
-            return HttpResponse::InternalServerError().json(ErrorBody {
+            return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                 title: "Server error",
                 status: 500,
                 detail: "Encountered error while attempting to create wrapper WDL to run test and evaluation",
-            });
+            }));
         }
     };
 
@@ -534,44 +578,45 @@ async fn run_for_test(
         Ok(mut file) => {
             if let Err(e) = write!(file, "{}", combined_wdl) {
                 error!("{}", e);
-                return HttpResponse::InternalServerError().json(ErrorBody {
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                     title: "Server error",
                     status: 500,
                     detail: "Encountered error while attempting to create temp file for submitting WDL to cromwell",
-                });
+                }));
             }
             file
         }
         Err(e) => {
             error!("{}", e);
-            return HttpResponse::InternalServerError().json(ErrorBody {
+            return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                 title: "Server error",
                 status: 500,
                 detail: "Encountered error while attempting to create temp file for submitting WDL to cromwell",
-            });
+            }));
         }
     };
     let json_file = match NamedTempFile::new() {
         Ok(mut file) => {
             let mut json_to_submit = test_json.clone();
             json_patch::merge(&mut json_to_submit, &eval_json);
+            let json_to_submit = format_json_for_cromwell(&json_to_submit)?;
             if let Err(e) = write!(file, "{}", json_to_submit.to_string()) {
                 error!("{}", e);
-                return HttpResponse::InternalServerError().json(ErrorBody {
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                     title: "Server error",
                     status: 500,
                     detail: "Encountered error while attempting to create temp file for submitting test params to cromwell",
-                });
+                }));
             }
             file
         }
         Err(e) => {
             error!("{}", e);
-            return HttpResponse::InternalServerError().json(ErrorBody {
+            return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                 title: "Server error",
                 status: 500,
                 detail: "Encountered error while attempting to create temp file for submitting test params to cromwell",
-            });
+            }));
         }
     };
 
@@ -596,11 +641,11 @@ async fn run_for_test(
         Ok(id_and_status) => id_and_status,
         Err(e) => {
             error!("{}", e);
-            return HttpResponse::InternalServerError().json(ErrorBody {
+            return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                 title: "Server error",
                 status: 500,
                 detail: &format!("Submitting job to Cromwell failed with error: {}", e),
-            });
+            }));
         }
     };
 
@@ -640,16 +685,45 @@ async fn run_for_test(
         Ok(run) => run,
         Err(e) => {
             error!("{}", e);
-            return HttpResponse::InternalServerError().json(ErrorBody {
+            return Ok(HttpResponse::InternalServerError().json(ErrorBody {
                 title: "Server error",
                 status: 500,
                 detail: "Encountered error while attempting to insert run record into DB",
-            });
+            }));
         }
     };
 
     // Return run to user
-    HttpResponse::Ok().json(run)
+    Ok(HttpResponse::Ok().json(run))
+}
+
+/// Returns `object` with necessary changes applied for submitting to cromwell as an input json
+///
+/// Input submitted in an input json to cromwell must be prefixed with `{workflow_name}.`
+/// This function returns a new json matchin `object` but with all the keys prefixed with
+/// `merged_workflow.` (the name used in crate::wdl::combiner for the workflow that runs the test
+/// wdl and then the eval wdl)
+fn format_json_for_cromwell(object: &Value) -> Result<Value, HttpResponse>{
+    // Get object as map
+    let object_map = match object.as_object() {
+        Some(map) => map,
+        None => return Err(HttpResponse::InternalServerError().json(ErrorBody{
+            title: "Could not parse json",
+            status: 500,
+            detail: "Could not parse input json as object.  This should not happen."
+        }))
+    };
+
+    let mut formatted_json = Map::new();
+
+    for key in object_map.keys() {
+        formatted_json.insert(
+            format!("merged_workflow.{}", key),
+            object.get(key).expect(&format!("Failed to get value for key {} from input json map.  This should never happen.", key)).to_owned()
+        );
+    }
+
+    Ok(formatted_json.into())
 }
 
 /// Attaches the REST mappings in this file to a service config
@@ -792,8 +866,8 @@ mod tests {
             name: String::from("Kevin's test test"),
             template_id: id,
             description: None,
-            test_input_defaults: Some(json!({"test_test.in_greeting": "Yo"})),
-            eval_input_defaults: Some(json!({"test_test.in_output_filename": "greeting.txt"})),
+            test_input_defaults: Some(json!({"in_greeting": "Yo"})),
+            eval_input_defaults: Some(json!({"in_output_filename": "greeting.txt"})),
             created_by: None,
         };
 
@@ -805,8 +879,8 @@ mod tests {
             name: String::from("Kevin's Run"),
             test_id: id,
             status: RunStatusEnum::Submitted,
-            test_input: json!({"test_test.in_greeted": "Cool Person", "test_test.in_greeting": "Yo"}),
-            eval_input: json!({"test_test.in_output_filename": "test_greeting.txt", "test_test.in_output_filename": "greeting.txt"}),
+            test_input: json!({"in_greeted": "Cool Person", "in_greeting": "Yo"}),
+            eval_input: json!({"in_output_filename": "test_greeting.txt", "in_output_filename": "greeting.txt"}),
             cromwell_job_id: Some(String::from("123456789")),
             created_by: Some(String::from("Kevin@example.com")),
             finished_at: None,
@@ -1101,8 +1175,8 @@ mod tests {
         let test_test =
             create_test_test_with_template_id(&pool.get().unwrap(), test_template.template_id);
 
-        let test_input = json!({"test_test.in_greeted": "Cool Person"});
-        let eval_input = json!({"test_test.in_output_filename": "test_greeting.txt"});
+        let test_input = json!({"in_greeted": "Cool Person"});
+        let eval_input = json!({"in_output_filename": "test_greeting.txt"});
         let new_run = NewRunIncomplete {
             name: None,
             test_input: Some(test_input.clone()),
@@ -1179,5 +1253,53 @@ mod tests {
         json_patch::merge(&mut eval_input_to_compare, &eval_input);
         assert_eq!(test_run.test_input, test_input_to_compare);
         assert_eq!(test_run.eval_input, eval_input_to_compare);
+    }
+
+    #[actix_rt::test]
+    async fn run_test_failure_taken_name() {
+        let pool = get_test_db_pool();
+
+        let test_id = Uuid::new_v4();
+        let test_run = create_test_run_with_test_id(&pool.get().unwrap(), test_id);
+
+        let test_input = json!({"in_greeted": "Cool Person"});
+        let eval_input = json!({"in_output_filename": "test_greeting.txt"});
+        let new_run = NewRunIncomplete {
+            name: Some(test_run.name.clone()),
+            test_input: Some(test_input.clone()),
+            eval_input: Some(eval_input.clone()),
+            created_by: None,
+        };
+
+        // Start up app for testing
+        let mut app = test::init_service(
+            App::new()
+                .data(pool)
+                .data(Client::default())
+                .configure(init_routes),
+        )
+        .await;
+
+        // Make request
+        let req = test::TestRequest::post()
+            .uri(&format!("/tests/{}/runs", test_id))
+            .set_json(&new_run)
+            .to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+
+        let result = test::read_body(resp).await;
+        let test_error: ErrorBody = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            test_error,
+            ErrorBody {
+                title: "Run with specified name already exists",
+                status: 400,
+                detail: "If a custom run name is specified, it must be unique.",
+            }
+        );
+
     }
 }

--- a/src/wdl/combiner.rs
+++ b/src/wdl/combiner.rs
@@ -65,14 +65,12 @@ pub fn combine_wdls(
     test_wdl_location: &str,
     eval_wdl: &str,
     eval_wdl_location: &str,
-    combined_name: &str,
 ) -> Result<String, CombineWdlError> {
     combine_wdls_with_sort_option(
         test_wdl,
         test_wdl_location,
         eval_wdl,
         eval_wdl_location,
-        combined_name,
         false,
     )
 }
@@ -89,7 +87,6 @@ fn combine_wdls_with_sort_option(
     test_wdl_location: &str,
     eval_wdl: &str,
     eval_wdl_location: &str,
-    combined_name: &str,
     sort: bool,
 ) -> Result<String, CombineWdlError> {
     let test_wdl = strip_comments(test_wdl);
@@ -116,7 +113,7 @@ fn combine_wdls_with_sort_option(
     let combined_wdl = format!(
         "import \"{}\" as test\n\
          import \"{}\" as eval\n\n\
-         workflow {} {{\n\
+         workflow merged_workflow {{\n\
          {}\n    \
          call test.{} as call_test {{\n        \
          input:\n{}\n    \
@@ -129,7 +126,6 @@ fn combine_wdls_with_sort_option(
          }}",
         test_wdl_location,
         eval_wdl_location,
-        combined_name.replace(" ", "_"),
         workflow_input_string,
         test_name,
         test_input_string,
@@ -360,7 +356,6 @@ mod tests {
             test_wdl_location,
             &eval_wdl,
             eval_wdl_location,
-            "merged_workflow",
             true,
         )
         .unwrap();
@@ -382,7 +377,6 @@ mod tests {
             test_wdl_location,
             &eval_wdl,
             eval_wdl_location,
-            "merged_workflow",
             true,
         );
         // Check if expected error was produced


### PR DESCRIPTION
1. Changed combiner to use 'merged_workflow' as the name of the combined workflow,
2. Added step in run_for_test function in routes::run for adding prefixes to keys in json that is submitted to cromwell,
3. Modified output processing in status_manager to look for results prefixed with 'merged_workflow.'

Also, fixed issue where user didn't get useful feedback when trying to run a test and specifying a name that is already taken