### PR TITLE
Fixed an issue causing run workflows to fail when they are specified in the template as gs uris

### DIFF
--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -1490,6 +1490,12 @@ mod tests {
         );
         let test_run_is_from_github =
             insert_test_run_is_from_github_with_run_id(&conn, test_run.run_id.clone());
+        // Define mockito mapping for wdl
+        let wdl_mock = mockito::mock("GET", "/eval.wdl")
+            .with_status(200)
+            .with_body(read_to_string("testdata/routes/run/eval_wdl.wdl").unwrap())
+            .expect(1)
+            .create();
         // Define mockito mapping for cromwell submit response
         let mock_response_body = json!({
           "id": "12345612-d114-4194-a7f7-9e41211ca2ce",
@@ -1820,6 +1826,13 @@ mod tests {
             test_run.run_id,
             test_software_version.software_version_id,
         );
+
+        // Define mockito mapping for wdl
+        let wdl_mock = mockito::mock("GET", "/test.wdl")
+            .with_status(200)
+            .with_body(read_to_string("testdata/routes/run/test_wdl.wdl").unwrap())
+            .expect(1)
+            .create();
 
         // Define mockito mapping for cromwell response
         let mock_response_body = json!({

--- a/src/manager/util.rs
+++ b/src/manager/util.rs
@@ -44,37 +44,6 @@ pub async fn start_job_from_file(
     cromwell_requests::start_job(&client, cromwell_params).await
 }
 
-/// Sends a request to cromwell to start a job from a WDL URL
-///
-/// Sends a request to Cromwell specifying the WDL pointed to by `wdl_url` for the workflow and the
-/// json at `json_file_path` for the inputs.  Returns the response as a WorkflowIdAndType or an
-/// error if there is some issue starting the job
-pub async fn start_job_from_url(
-    client: &Client,
-    wdl_url: &str,
-    json_file_path: &Path,
-) -> Result<WorkflowIdAndStatus, CromwellRequestError> {
-    // Build request parameters
-    let cromwell_params = cromwell_requests::StartJobParams {
-        labels: None,
-        workflow_dependencies: None,
-        workflow_inputs: Some(PathBuf::from(json_file_path)),
-        workflow_inputs_2: None,
-        workflow_inputs_3: None,
-        workflow_inputs_4: None,
-        workflow_inputs_5: None,
-        workflow_on_hold: None,
-        workflow_options: None,
-        workflow_root: None,
-        workflow_source: None,
-        workflow_type: Some(WorkflowTypeEnum::WDL),
-        workflow_type_version: None,
-        workflow_url: Some(String::from(wdl_url)),
-    };
-    // Submit request to start job
-    cromwell_requests::start_job(&client, cromwell_params).await
-}
-
 /// Creates a temporary file with `contents` and returns it
 ///
 /// Creates a NamedTempFile and writes `contents` to it.  Returns the file if successful.  Returns


### PR DESCRIPTION
Cromwell's workflow submission endpoint doesn't like gs uris in the workflowUrl param.  Changed the run code to instead download from the gs uri and then submit the workflow as a file.