### PR TITLE
Modified image build regex to allow for git tags

### DIFF
--- a/src/manager/test_runner.rs
+++ b/src/manager/test_runner.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 lazy_static! {
     // Build regex for matching values specifying custom builds
     static ref IMAGE_BUILD_REGEX: Regex =
-        Regex::new(r"image_build:\w[^\|]*\|[0-9a-f]{40}").unwrap();
+        Regex::new(r"image_build:\w[^\|]*\|.*").unwrap();
 
     // Build regex for matching values specifying test outputs
     static ref TEST_OUTPUT_REGEX: Regex =


### PR DESCRIPTION
Took the regex we're using to determine in an input is specifying a software build and modified it to allow any string of characters after the pipe.  This will allow specifying git tags for software builds, instead of just commit hashes.  I opted not to build a more complicated regex to match the allowed format of a git tag, because doing it this way will mean the build will fail when it tries to clone the repo, which should give better feedback than if it failed on the regex match.