### PR TITLE
Runs with missing results will fail and runs that fail to start after building will send notifications

### DIFF
--- a/src/manager/report_builder.rs
+++ b/src/manager/report_builder.rs
@@ -907,8 +907,8 @@ mod tests {
     use crate::manager::report_builder::{
         create_input_json, create_report_template, create_run_report,
         create_run_reports_for_completed_run, get_control_block_values,
-        get_disk_size_based_on_inputs_and_results, Error,
-        FILE_DOWNLOAD_CELL, RUN_METADATA_CELL, RUN_INPUTS_AND_RESULTS_CELL
+        get_disk_size_based_on_inputs_and_results, Error, FILE_DOWNLOAD_CELL,
+        RUN_INPUTS_AND_RESULTS_CELL, RUN_METADATA_CELL,
     };
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::report::{NewReport, ReportData};

--- a/src/manager/test_runner.rs
+++ b/src/manager/test_runner.rs
@@ -295,13 +295,7 @@ pub async fn start_run_test(
     // Retrieve test for id or return error
     let test = get_test(&conn, run.test_id.clone())?;
 
-    match start_run_test_with_template_id(conn, client, run, test.template_id).await {
-        Ok(run) => Ok(run),
-        Err(e) => {
-            update_run_status(conn, run.run_id, RunStatusEnum::CarrotFailed)?;
-            return Err(e);
-        }
-    }
+    start_run_test_with_template_id(conn, client, run, test.template_id).await
 }
 
 /// Starts a run by submitting the test wdl to cromwell

--- a/src/routes/error_handling.rs
+++ b/src/routes/error_handling.rs
@@ -1,8 +1,8 @@
 //! Defines structs and functions for error handling functionality that is shared among routes
 //! modules
 
-use serde::{Deserialize, Serialize};
 use actix_web::HttpResponse;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 /// Struct to use for returning error responses from REST endpoints
@@ -22,6 +22,9 @@ pub fn default_500(error_message: &impl Display) -> HttpResponse {
     HttpResponse::InternalServerError().json(ErrorBody {
         title: "Server error".to_string(),
         status: 500,
-        detail: format!("Encountered the following error while trying to process your request: {}", error_message),
+        detail: format!(
+            "Encountered the following error while trying to process your request: {}",
+            error_message
+        ),
     })
 }

--- a/src/routes/pipeline.rs
+++ b/src/routes/pipeline.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::pipeline::{NewPipeline, PipelineChangeset, PipelineData, PipelineQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde_json::json;

--- a/src/routes/report.rs
+++ b/src/routes/report.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::report::{NewReport, ReportChangeset, ReportData, ReportQuery, UpdateError};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde_json::json;

--- a/src/routes/result.rs
+++ b/src/routes/result.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::result::{NewResult, ResultChangeset, ResultData, ResultQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde_json::json;

--- a/src/routes/run.rs
+++ b/src/routes/run.rs
@@ -7,7 +7,7 @@ use crate::custom_sql_types::RunStatusEnum;
 use crate::db;
 use crate::manager::test_runner;
 use crate::models::run::{DeleteError, RunData, RunQuery, RunWithResultData};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::dev::HttpResponseBuilder;
 use actix_web::http::StatusCode;
 use actix_web::{client::Client, error::BlockingError, web, HttpRequest, HttpResponse, Responder};

--- a/src/routes/run_report.rs
+++ b/src/routes/run_report.rs
@@ -6,7 +6,7 @@
 use crate::db;
 use crate::manager::report_builder;
 use crate::models::run_report::{RunReportData, RunReportQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::client::Client;
 use actix_web::dev::HttpResponseBuilder;
 use actix_web::http::StatusCode;
@@ -432,9 +432,9 @@ mod tests {
     use chrono::Utc;
     use diesel::PgConnection;
     use serde_json::Value;
+    use std::env;
     use std::fs::read_to_string;
     use uuid::Uuid;
-    use std::env;
 
     fn insert_test_run(conn: &PgConnection) -> RunData {
         let new_pipeline = NewPipeline {

--- a/src/routes/software.rs
+++ b/src/routes/software.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::software::{NewSoftware, SoftwareChangeset, SoftwareData, SoftwareQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use crate::util::git_repos;
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse};
 use log::error;

--- a/src/routes/software_build.rs
+++ b/src/routes/software_build.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::software_build::{SoftwareBuildData, SoftwareBuildQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use uuid::Uuid;

--- a/src/routes/software_version.rs
+++ b/src/routes/software_version.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::software_version::{SoftwareVersionData, SoftwareVersionQuery};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use uuid::Uuid;

--- a/src/routes/subscription.rs
+++ b/src/routes/subscription.rs
@@ -11,7 +11,7 @@ use crate::models::subscription::{
 };
 use crate::models::template::TemplateData;
 use crate::models::test::TestData;
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpResponse};
 use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
@@ -548,9 +548,7 @@ async fn verify_existence(
                 })
             }
             // For other errors, return a 500
-            _ => {
-                default_500(&e)
-            }
+            _ => default_500(&e),
         }
     })
 }

--- a/src/routes/template.rs
+++ b/src/routes/template.rs
@@ -7,7 +7,7 @@ use crate::db;
 use crate::models::template::{
     NewTemplate, TemplateChangeset, TemplateData, TemplateQuery, UpdateError,
 };
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use crate::validation::womtool;
 use actix_web::client::Client;
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};

--- a/src/routes/template_report.rs
+++ b/src/routes/template_report.rs
@@ -7,7 +7,7 @@ use crate::db;
 use crate::models::template_report::{
     DeleteError, NewTemplateReport, TemplateReportData, TemplateReportQuery,
 };
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde::{Deserialize, Serialize};

--- a/src/routes/template_result.rs
+++ b/src/routes/template_result.rs
@@ -7,7 +7,7 @@ use crate::db;
 use crate::models::template_result::{
     DeleteError, NewTemplateResult, TemplateResultData, TemplateResultQuery,
 };
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde::{Deserialize, Serialize};

--- a/src/routes/test.rs
+++ b/src/routes/test.rs
@@ -5,7 +5,7 @@
 
 use crate::db;
 use crate::models::test::{NewTest, TestChangeset, TestData, TestQuery, UpdateError};
-use crate::routes::error_handling::{ ErrorBody, default_500 };
+use crate::routes::error_handling::{default_500, ErrorBody};
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse, Responder};
 use log::error;
 use serde_json::json;


### PR DESCRIPTION
Fixes two bugs:

1. Runs would not be marked as failed when there were results missing from what was expected, based on the results mapped to the run's template. (Fixes #146 )
2. Runs that failed in some part of the test-starting process after completing a build would not send notifications of the run's failure.