### PR TITLE
Added an option to store WDLs in GCS instead of locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,14 @@ CARROT_GCLOUD_SA_KEY_FILE=/path/to/key/file.json
 # Where to store WDLs locally (defaults to /carrot/wdl)
 # CARROT_WDL_DIRECTORY=
 
+# Where to store WDLs locally (defaults to /carrot/wdl)
+# WDL_DIRECTORY=
+# For enabling storing WDLs in Google Cloud Storage, instead of locally (defaults to false)
+# ENABLE_GCS_WDL_STORAGE=true
+# GCS directory where we'll put WDL files if we're using GCS for WDL storage (in the form
+# gs://bucket-name/my/report/directory)
+# GCS_WDL_LOCATION=gs://bucket-name/my/report/directory
+
 # For enabling subscribing to a Google Cloud Pub/Sub topic, which is necessary for processing
 # test run requests from GitHub
 #CARROT_ENABLE_GITHUB_REQUESTS=true

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,20 @@ lazy_static! {
         Ok(val) => val,
         Err(_) => String::from("/carrot/wdl"),
     };
+    /// If true, WDLs will be stored in the GCS bucket specified by GCS_WDL_LOCATION
+    pub static ref ENABLE_GCS_WDL_STORAGE: bool = match env::var("CARROT_ENABLE_GCS_WDL_STORAGE") {
+        Ok(val) => {
+            if val == "true" {
+                true
+            } else {
+                false
+            }
+        }
+        Err(_) => false,
+    };
+    /// The GCS location in which to store WDLs if ENABLE_GCS_WDL_STORAGE is true
+    pub static ref GCS_WDL_LOCATION: String = env::var("CARROT_GCS_WDL_LOCATION")
+        .expect("GCS_WDL_LOCATION environment variable not set");
 
     // GITHUB
     /// If true, enables triggering carrot test runs from github
@@ -233,6 +247,12 @@ pub fn initialize() {
 
     // WDL Storage
     lazy_static::initialize(&WDL_DIRECTORY);
+    lazy_static::initialize(&ENABLE_GCS_WDL_STORAGE);
+    // If we're storing our WDLs in a gcs bucket, make sure we initialize the variable for the
+    // bucket
+    if *ENABLE_GCS_WDL_STORAGE {
+        lazy_static::initialize(&GCS_WDL_LOCATION);
+    }
 
     // Emailer
     lazy_static::initialize(&EMAIL_MODE);

--- a/src/routes/template.rs
+++ b/src/routes/template.rs
@@ -236,6 +236,18 @@ async fn update(
     pool: web::Data<db::DbPool>,
     client: web::Data<Client>,
 ) -> impl Responder {
+    // If either WDL is a gs uri, make sure those are allowed
+    if let Some(test_wdl) = &template_changes.test_wdl {
+        if test_wdl.starts_with(gcloud_storage::GS_URI_PREFIX) {
+            is_gs_uris_for_wdls_enabled()?;
+        }
+    }
+    if let Some(eval_wdl) = &template_changes.eval_wdl {
+        if eval_wdl.starts_with(gcloud_storage::GS_URI_PREFIX) {
+            is_gs_uris_for_wdls_enabled()?;
+        }
+    }
+
     //Parse ID into Uuid
     let id = match Uuid::parse_str(&*id_param) {
         Ok(id) => id,

--- a/src/util/temp_storage.rs
+++ b/src/util/temp_storage.rs
@@ -30,3 +30,4 @@ pub fn get_temp_file(contents: &str) -> Result<NamedTempFile, std::io::Error> {
         }
     }
 }
+


### PR DESCRIPTION
Modified the process by which template creation and updating works to store WDLs locally or in GCS depending on configuration.  

In the case that a server running CARROT at some point switches from local storage to GCS storage, GCS storage will be used for newly-created templates, but existing templates will not be changed.  The same applies for switching in the opposite direction.  Although both are somewhat unlikely use cases.

Closes #136 