### PR TITLE
Modified logging config to make it possible to specify logging levels at the module level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-web",
- "base64 0.9.3",
+ "base64 0.13.0",
  "chrono",
  "clap",
  "ctrlc",
@@ -2553,14 +2553,14 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.13.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7de33c687404ec3045d4a0d437580455257c0436f858d702f244e7d652f9f07"
+checksum = "45b60258a35dc3cb8a16890b8fd6723349bfa458d7960e25e633f1b1c19d7b5e"
 dependencies = [
  "atty",
- "chrono",
  "colored 1.9.3",
  "log 0.4.14",
+ "time 0.3.5",
  "winapi 0.3.9",
 ]
 
@@ -2776,9 +2776,20 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check 0.9.3",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa",
+ "libc",
+ "time-macros 0.2.3",
 ]
 
 [[package]]
@@ -2790,6 +2801,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "time-macros-impl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ openssl = "0.10"
 # Environment variables
 dotenv = "0.15.0"
 # Logging
-simple_logger = "1.13"
+simple_logger = "1.16"
 log = { version = "0.4.14", features = ["serde"] }
 # DB connection and pooling
 diesel = { version = "1.4.3", features = ["postgres", "r2d2", "uuidv07", "chrono", "serde_json"] }

--- a/carrot.example.yml
+++ b/carrot.example.yml
@@ -82,4 +82,10 @@ reporting:
   report_docker_location: us.gcr.io/example/vis_docker:latest
 # Config for logging level of carrot
 logging:
+  # The default logging level you want to use for all modules
   level: DEBUG
+  # Optionally, you can override the default logging level for specific modules using the name of the module as the key
+  # e.g. maybe hyper and rustls are more verbose than needed at DEBUG level, so we've overridden them to use INFO
+  modules:
+    hyper: INFO
+    rustls: INFO

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! from here instead of loaded again elsewhere
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Top level config struct that holds other area-specific configs
 #[derive(Serialize, Deserialize, Clone)]
@@ -179,6 +180,8 @@ impl Config {
 pub struct LoggingConfig {
     #[serde(default = "logging_level_default")]
     level: log::Level,
+    #[serde(default)]
+    modules: HashMap<String, log::Level>,
 }
 
 // Function for providing the default value
@@ -187,11 +190,14 @@ fn logging_level_default() -> log::Level {
 }
 
 impl LoggingConfig {
-    pub fn new(level: log::Level) -> Self {
-        LoggingConfig { level }
+    pub fn new(level: log::Level, modules: HashMap<String, log::Level>) -> Self {
+        LoggingConfig { level, modules }
     }
     pub fn level(&self) -> &log::Level {
         &self.level
+    }
+    pub fn modules(&self) -> &HashMap<String, log::Level> {
+        &self.modules
     }
 }
 
@@ -429,11 +435,14 @@ pub struct WdlStorageConfig {
 
 // Function for providing the default value
 fn wdl_directory_default() -> String {
-    let mut current_dir = std::env::current_dir()
-        .expect("Failed to get current directory for wdl directory default");
+    let mut current_dir =
+        std::env::current_dir().expect("Failed to get current directory for wdl directory default");
     current_dir.push("carrot");
     current_dir.push("wdl");
-    current_dir.to_str().expect("Failed to convert wdl directory path to string").to_string()
+    current_dir
+        .to_str()
+        .expect("Failed to convert wdl directory path to string")
+        .to_string()
 }
 
 // Defining a default value for WdlStorageConfig so the user doesn't have to explicitly specify it

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,8 +113,14 @@ fn main() {
     };
 
     // Initialize logger with level from config
-    simple_logger::init_with_level(carrot_config.logging().level().to_owned())
-        .expect("Failed to initialize logger");
+    let mut logger = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
+        .with_level(carrot_config.logging().level().to_owned().to_level_filter());
+    // Add any module-specific levels
+    for item in carrot_config.logging().modules() {
+        logger = logger.with_module_level(item.0, item.1.to_owned().to_level_filter());
+    }
+    logger.init().expect("Failed to initialize logger");
 
     // Create atomic variable for tracking whether user has hit Ctrl-C
     let user_term = Arc::new(AtomicBool::new(true));

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -51,7 +51,7 @@ enum CromwellStatus {
     Failed,
     Aborted,
     Aborting,
-    Other(String)
+    Other(String),
 }
 
 /// Implementing From<&str> and Display for CromwellStatus so we can easily convert to and from the raw
@@ -68,7 +68,7 @@ impl std::convert::From<&str> for CromwellStatus {
             "failed" => Self::Failed,
             "aborted" => Self::Aborted,
             "aborting" => Self::Aborting,
-            _ => Self::Other(String::from(s))
+            _ => Self::Other(String::from(s)),
         }
     }
 }
@@ -84,7 +84,7 @@ impl fmt::Display for CromwellStatus {
             CromwellStatus::Failed => write!(f, "failed"),
             CromwellStatus::Aborted => write!(f, "aborted"),
             CromwellStatus::Aborting => write!(f, "aborting"),
-            CromwellStatus::Other(s) => write!(f, "{}", s)
+            CromwellStatus::Other(s) => write!(f, "{}", s),
         }
     }
 }
@@ -1161,7 +1161,9 @@ impl StatusManager {
                 CromwellStatus::Running => Some(RunStatusEnum::TestRunning),
                 CromwellStatus::Starting => Some(RunStatusEnum::TestStarting),
                 CromwellStatus::QueuedInCromwell => Some(RunStatusEnum::TestQueuedInCromwell),
-                CromwellStatus::WaitingForQueueSpace => Some(RunStatusEnum::TestWaitingForQueueSpace),
+                CromwellStatus::WaitingForQueueSpace => {
+                    Some(RunStatusEnum::TestWaitingForQueueSpace)
+                }
                 CromwellStatus::Succeeded => Some(RunStatusEnum::Succeeded),
                 CromwellStatus::Failed => Some(RunStatusEnum::TestFailed),
                 CromwellStatus::Aborted => Some(RunStatusEnum::TestAborted),
@@ -1174,7 +1176,9 @@ impl StatusManager {
                 CromwellStatus::Running => Some(RunStatusEnum::EvalRunning),
                 CromwellStatus::Starting => Some(RunStatusEnum::EvalStarting),
                 CromwellStatus::QueuedInCromwell => Some(RunStatusEnum::EvalQueuedInCromwell),
-                CromwellStatus::WaitingForQueueSpace => Some(RunStatusEnum::EvalWaitingForQueueSpace),
+                CromwellStatus::WaitingForQueueSpace => {
+                    Some(RunStatusEnum::EvalWaitingForQueueSpace)
+                }
                 CromwellStatus::Succeeded => Some(RunStatusEnum::Succeeded),
                 CromwellStatus::Failed => Some(RunStatusEnum::EvalFailed),
                 CromwellStatus::Aborted => Some(RunStatusEnum::EvalAborted),
@@ -1185,7 +1189,9 @@ impl StatusManager {
     }
 
     /// Returns equivalent BuildStatusEnum for `cromwell_status`
-    fn get_build_status_for_cromwell_status(cromwell_status: CromwellStatus) -> Option<BuildStatusEnum> {
+    fn get_build_status_for_cromwell_status(
+        cromwell_status: CromwellStatus,
+    ) -> Option<BuildStatusEnum> {
         match cromwell_status {
             CromwellStatus::Submitted => Some(BuildStatusEnum::Submitted),
             CromwellStatus::Running => Some(BuildStatusEnum::Running),
@@ -1200,9 +1206,11 @@ impl StatusManager {
     }
 
     /// Returns equivalent ReportStatusEnum for `cromwell_status`
-    fn get_report_status_for_cromwell_status(cromwell_status: CromwellStatus) -> Option<ReportStatusEnum> {
+    fn get_report_status_for_cromwell_status(
+        cromwell_status: CromwellStatus,
+    ) -> Option<ReportStatusEnum> {
         match cromwell_status {
-            CromwellStatus::Submitted  => Some(ReportStatusEnum::Submitted),
+            CromwellStatus::Submitted => Some(ReportStatusEnum::Submitted),
             CromwellStatus::Running => Some(ReportStatusEnum::Running),
             CromwellStatus::Starting => Some(ReportStatusEnum::Starting),
             CromwellStatus::QueuedInCromwell => Some(ReportStatusEnum::QueuedInCromwell),


### PR DESCRIPTION
Some of the modules have very verbose logging at the debug level and I mainly made this change so I can quiet those modules when I'm using debug logging.

Closes #165 