### PR TITLE
Uploading wdls for create and update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.14",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.2.0",
 ]
 
@@ -29,7 +29,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project 0.4.28",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.3.1",
 ]
 
@@ -113,6 +113,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-multipart"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774bfeb11b54bf9c857a005b8ab893293da4eaff79261a66a9200dab7f5ab6e3"
+dependencies = [
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "bytes 0.5.6",
+ "derive_more",
+ "futures-util",
+ "httparse",
+ "log 0.4.14",
+ "mime 0.3.16",
+ "twoway",
+]
+
+[[package]]
 name = "actix-multipart-rfc7578"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +168,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -512,6 +530,7 @@ name = "carrot"
 version = "0.3.2"
 dependencies = [
  "actix-codec 0.2.0",
+ "actix-multipart",
  "actix-multipart-rfc7578",
  "actix-rt",
  "actix-service",
@@ -525,6 +544,8 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "futures",
+ "futures-core",
+ "futures-util",
  "google-pubsub1",
  "google-storage1",
  "hyper",
@@ -551,6 +572,8 @@ dependencies = [
  "simple_logger",
  "tempfile",
  "threadpool",
+ "tokio 1.15.0",
+ "tokio-stream",
  "uuid 0.8.2",
  "validator",
  "yup-oauth2",
@@ -1201,7 +1224,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
@@ -1936,7 +1959,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log 0.4.14",
- "tokio",
+ "tokio 0.2.25",
  "tokio-postgres",
 ]
 
@@ -2857,13 +2880,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+dependencies = [
+ "pin-project-lite 0.2.7",
+]
+
+[[package]]
 name = "tokio-openssl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2884,8 +2916,19 @@ dependencies = [
  "pin-project-lite 0.1.12",
  "postgres-protocol",
  "postgres-types",
- "tokio",
+ "tokio 0.2.25",
  "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.7",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -2899,7 +2942,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.12",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2913,7 +2956,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.14",
  "pin-project-lite 0.1.12",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2978,7 +3021,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "url 2.2.2",
 ]
 
@@ -2997,8 +3040,18 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "trust-dns-proto",
+]
+
+[[package]]
+name = "twoway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
+dependencies = [
+ "memchr",
+ "unchecked-index",
 ]
 
 [[package]]
@@ -3018,6 +3071,12 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ actix-web = { version = "^3.3.2", features=["openssl"] }
 actix-rt = "1.0.0"
 actix-service = "1.0.5"
 actix-codec = "0.2.0"
+actix-multipart = "0.3.0" # For receiving multipart data
 actix-multipart-rfc7578 = "0.4.0" # For sending files in requests
 # For SSL requests
 openssl = "0.10"
@@ -77,4 +78,9 @@ mockito = "0.30"
 # For parsing test emails
 mailparse = "0.13.0"
 serde_bytes = "0.11"
+# For testing multipart parsing
+tokio = { version = "1.8.4", features = ["sync"] }
+tokio-stream = "0.1"
+futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.7", default-features = false, features = ["alloc"] }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51.0 as builder
+FROM rust:1.55.0 as builder
 WORKDIR /usr/src/carrot
 COPY . .
 RUN cargo install --path .

--- a/scripts/docker/test/Dockerfile
+++ b/scripts/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51.0
+FROM rust:1.55.0
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get -y --no-install-recommends install \

--- a/src/manager/report_builder.rs
+++ b/src/manager/report_builder.rs
@@ -421,9 +421,9 @@ impl ReportBuilder {
             &report.config,
         )?;
         // Write it to a file
-        let json_file = temp_storage::get_temp_file(&input_json.to_string())?;
+        let json_file = temp_storage::get_temp_file(&input_json.to_string().as_bytes())?;
         // Write the wdl to a file
-        let wdl_file = temp_storage::get_temp_file(generator_wdl)?;
+        let wdl_file = temp_storage::get_temp_file(generator_wdl.as_bytes())?;
         // Submit report generation job to cromwell
         let start_job_response =
             util::start_job_from_file(&self.cromwell_client, &wdl_file.path(), &json_file.path())
@@ -740,7 +740,7 @@ impl ReportBuilder {
         run_name: &str,
     ) -> Result<String, Error> {
         // Write the json to a temporary file
-        let report_file = match temp_storage::get_temp_file(&report_json.to_string()) {
+        let report_file = match temp_storage::get_temp_file(&report_json.to_string().as_bytes()) {
             Ok(file) => file,
             Err(e) => {
                 error!("Failed to create temp file for uploading report template");
@@ -753,7 +753,7 @@ impl ReportBuilder {
         // Upload that file to GCS
         Ok(self
             .gcloud_client
-            .upload_file_to_gs_uri(report_file, &self.config.report_location(), &report_name)
+            .upload_file_to_gs_uri(&report_file, &self.config.report_location(), &report_name)
             .await?)
     }
 
@@ -1195,7 +1195,7 @@ mod tests {
             },
         ));
         gcloud_client.set_upload_file(Box::new(
-            |f: File,
+            |f: &File,
              address: &str,
              name: &str|
              -> Result<String, crate::storage::gcloud_storage::Error> {

--- a/src/manager/software_builder.rs
+++ b/src/manager/software_builder.rs
@@ -91,7 +91,7 @@ impl SoftwareBuilder {
         };
 
         // Put it in a temporary file to be sent with cromwell request
-        let wdl_file = temp_storage::get_temp_file(wdl_to_use)?;
+        let wdl_file = temp_storage::get_temp_file(wdl_to_use.as_bytes())?;
 
         // Create path to wdl that builds docker images
         let wdl_file_path: &Path = &wdl_file.path();
@@ -122,7 +122,7 @@ impl SoftwareBuilder {
         };
 
         // Write json to temp file so it can be submitted to cromwell
-        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string())?;
+        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string().as_bytes())?;
 
         // Send job request to cromwell
         let start_job_response =

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -1731,7 +1731,7 @@ mod tests {
             Some(gcloud_config) => {
                 let mut gcloud_client = GCloudClient::new(gcloud_config.gcloud_sa_key_file());
                 gcloud_client.set_upload_file(Box::new(
-                    |f: File,
+                    |f: &File,
                      address: &str,
                      name: &str|
                      -> Result<String, crate::storage::gcloud_storage::Error> {

--- a/src/manager/test_runner.rs
+++ b/src/manager/test_runner.rs
@@ -296,14 +296,14 @@ impl TestRunner {
         let json_to_submit = self.format_test_json_for_cromwell(&run.test_input)?;
 
         // Write json to temp file so it can be submitted to cromwell
-        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string())?;
+        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string().as_bytes())?;
 
         // Download test wdl and write it to a file
         let test_wdl_as_string = self
             .test_resource_client
             .get_resource_as_string(&template.test_wdl)
             .await?;
-        let test_wdl_as_file = temp_storage::get_temp_file(&test_wdl_as_string)?;
+        let test_wdl_as_file = temp_storage::get_temp_file(&test_wdl_as_string.as_bytes())?;
 
         // Send job request to cromwell
         let start_job_response = match util::start_job_from_file(
@@ -385,14 +385,14 @@ impl TestRunner {
         let json_to_submit = self.format_eval_json_for_cromwell(&run.eval_input, test_outputs)?;
 
         // Write json to temp file so it can be submitted to cromwell
-        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string())?;
+        let json_file = temp_storage::get_temp_file(&json_to_submit.to_string().as_bytes())?;
 
         // Download eval wdl and write it to a file
         let eval_wdl_as_string = self
             .test_resource_client
             .get_resource_as_string(&template.eval_wdl)
             .await?;
-        let eval_wdl_as_file = temp_storage::get_temp_file(&eval_wdl_as_string)?;
+        let eval_wdl_as_file = temp_storage::get_temp_file(&eval_wdl_as_string.as_bytes())?;
 
         // Send job request to cromwell
         let start_job_response = match util::start_job_from_file(

--- a/src/manager/util.rs
+++ b/src/manager/util.rs
@@ -94,7 +94,7 @@ mod tests {
             "myWorkflow.test":"test"
         });
         // Write them to a temp file
-        let test_json_file = temp_storage::get_temp_file(&params.to_string()).unwrap();
+        let test_json_file = temp_storage::get_temp_file(&params.to_string().as_bytes()).unwrap();
         // Define mockito mapping for response
         let mock_response_body = json!({
           "id": "53709600-d114-4194-a7f7-9e41211ca2ce",

--- a/src/requests/test_resource_requests.rs
+++ b/src/requests/test_resource_requests.rs
@@ -82,7 +82,8 @@ impl TestResourceClient {
 
     /// Returns body of resource at `address` as a String
     ///
-    /// Sends a get request to `address` and parses the response body as a String
+    /// Reads resource at `address` and returns it as a String.  `address` can be an http(s) url, gs
+    /// uri (if `self` has a value for `gcs_client`), or a local file path
     pub async fn get_resource_as_string(&self, address: &str) -> Result<String, Error> {
         // If the address is a gs address and retrieving from gs addresses is enabled, retrieve the data
         // using the gcloud storage api
@@ -95,7 +96,7 @@ impl TestResourceClient {
         }
         // If it's an http/https url, make an http request
         else if address.starts_with("http://") || address.starts_with("https://") {
-            self.get_resource_from_http_url(address).await
+            self.get_resource_as_string_from_http_url(address).await
         }
         // Otherwise, we'll assume it's a local file
         else {
@@ -103,8 +104,8 @@ impl TestResourceClient {
         }
     }
 
-    /// Attempts to retrieve and return the resource at `address`
-    async fn get_resource_from_http_url(&self, address: &str) -> Result<String, Error> {
+    /// Attempts to retrieve and return the resource at `address` as a String
+    async fn get_resource_as_string_from_http_url(&self, address: &str) -> Result<String, Error> {
         let request = self.http_client.get(format!("{}", address));
 
         // Make the request

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -17,3 +17,5 @@ pub mod test;
 
 mod disabled_features;
 mod error_handling;
+mod multipart_handling;
+mod util;

--- a/src/routes/multipart_handling.rs
+++ b/src/routes/multipart_handling.rs
@@ -1,0 +1,509 @@
+//! Defines functionality for processing multipart data received by API routes defined within the
+//! routes submodules
+
+use crate::routes::error_handling::ErrorBody;
+use actix_multipart::Multipart;
+use actix_web::dev::RequestHead;
+use actix_web::web::{BufMut, BytesMut};
+use actix_web::HttpResponse;
+use futures::{StreamExt, TryStreamExt};
+use log::warn;
+use std::collections::HashMap;
+use std::fmt;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[derive(Debug)]
+pub enum Error {
+    Multipart(actix_multipart::MultipartError),
+    /// An error parsing a field that is expected to be text as a string
+    ParseAsString(String, std::str::Utf8Error),
+    IO(std::io::Error),
+    /// Indicates the presence of an unexpected field
+    UnexpectedField(String),
+    /// Failure to retrieve necessary information (such as content disposition or name) from a field
+    FieldFormat(String),
+    /// Indicates the absence of a required field
+    MissingField(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Multipart(e) => write!(f, "Multipart Handling Error Multipart {}", e),
+            Error::ParseAsString(s, e) => write!(
+                f,
+                "Multipart Handling Error ParseAsString data: {}, error: {}",
+                s, e
+            ),
+            Error::IO(e) => write!(f, "Multipart Handling Error IO {}", e),
+            Error::UnexpectedField(s) => {
+                write!(f, "Multipart Handling Error Unexpected Field {}", s)
+            }
+            Error::FieldFormat(s) => write!(f, "Multipart Handling Error Field Format {}", s),
+            Error::MissingField(s) => write!(f, "Multipart Handling Error Missing Field {}", s),
+        }
+    }
+}
+
+// Implementing a default conversion of the different Error possibilities into an http error
+// response, to avoid rewriting the responses wherever Error is likely to be encountered
+impl From<Error> for HttpResponse {
+    fn from(err: Error) -> HttpResponse {
+        match err {
+            Error::Multipart(e) => HttpResponse::BadRequest().json(
+                ErrorBody {
+                    title: "Failed to parse multipart data".to_string(),
+                    status: 400,
+                    detail: format!("Encountered the following error while trying to process multipart payload: {}", e)
+                }
+            ),
+            Error::ParseAsString(s, e) => HttpResponse::BadRequest().json(
+                ErrorBody{
+                    title: "Failed to parse field as text".to_string(),
+                    status: 400,
+                    detail: format!("While attempting to parse {} as text, encountered the following error: {}", s, e)
+                }
+            ),
+            Error::IO(e) => HttpResponse::InternalServerError().json(
+                ErrorBody{
+                    title: "Encountered an error trying to process file data".to_string(),
+                    status: 500,
+                    detail: format!("Encountered the following error while attempting to process file data from multipart payload: {}", e)
+                }
+            ),
+            Error::UnexpectedField(s) => HttpResponse::BadRequest().json(
+                ErrorBody{
+                    title: "Encountered an expected field".to_string(),
+                    status: 400,
+                    detail: format!("Unexpected field {} was encountered while parsing multipart payload", s)
+                }
+            ),
+            Error::FieldFormat(s) => HttpResponse::BadRequest().json(
+                ErrorBody{
+                    title: "Encountered an error processing multipart field".to_string(),
+                    status: 400,
+                    detail: format!("Encountered the following error attempting to parse multipart field: {}", s)
+                }
+            ),
+            Error::MissingField(s) => HttpResponse::BadRequest().json(
+                ErrorBody{
+                    title: "Missing required field".to_string(),
+                    status: 400,
+                    detail: format!("Payload does not contain required field: {}", s)
+                }
+            )
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<actix_multipart::MultipartError> for Error {
+    fn from(e: actix_multipart::MultipartError) -> Error {
+        Error::Multipart(e)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Error {
+        Error::IO(e)
+    }
+}
+
+/// Accepts a multipart `payload` and lists of text and file fields expected to be found in that
+/// payload.  Attempts to extract those fields from `payload` and return a map of each extracted
+/// text field and each extracted file field.
+/// Returns an error if:
+/// 1. Loading the payload data fails,
+/// 2. Parsing any of the fields fails,
+/// 3. Writing the data for a file field to a temporary file fails, or
+/// 4. A field is encountered that is not present in either of the expected field lists
+pub async fn extract_data_from_multipart(
+    mut payload: Multipart,
+    expected_text_fields: &Vec<&str>,
+    expected_file_fields: &Vec<&str>,
+    required_text_fields: &Vec<&str>,
+    required_file_fields: &Vec<&str>,
+) -> Result<(HashMap<String, String>, HashMap<String, NamedTempFile>), Error> {
+    // Build maps of the fields we process to return
+    let mut string_map: HashMap<String, String> = HashMap::new();
+    let mut file_map: HashMap<String, NamedTempFile> = HashMap::new();
+    // Iterate over the payload
+    while let Ok(Some(mut field)) = payload.try_next().await {
+        // Get the content disposition so we can get the name from it
+        let content_disposition = match field.content_disposition() {
+            Some(val) => val,
+            None => {
+                return Err(Error::FieldFormat(format!(
+                    "Failed to parse content disposition for field {:?}",
+                    field
+                )));
+            }
+        };
+        // Get the name of the field
+        let field_name = match content_disposition.get_name() {
+            Some(val) => val,
+            None => {
+                return Err(Error::FieldFormat(format!(
+                    "Failed to parse name from content disposition {:?}",
+                    content_disposition
+                )));
+            }
+        };
+        // Determine what to do with the data based on the name
+        // If it's an expected text field, process it as text
+        if expected_text_fields.contains(&field_name) {
+            // If it's one of the string fields, read the bytes and then convert to a string
+            let mut data_buffer = BytesMut::new();
+            while let Some(data) = field.next().await {
+                // Write the data to our buffer
+                data_buffer.put(data?);
+            }
+            // Convert our buffer to a string and assign it
+            let data_string = match std::str::from_utf8(&data_buffer) {
+                Ok(data_string) => data_string,
+                Err(e) => {
+                    return Err(Error::ParseAsString(format!("{:?}", data_buffer), e));
+                }
+            };
+            // Put it in our data map so we can stick it in the report struct at the end
+            string_map.insert(String::from(field_name), String::from(data_string));
+        }
+        // If it's an expected file field, write it to a temp file
+        else if expected_file_fields.contains(&field_name) {
+            // If it's one of the file fields, read the bytes and write to a temp file
+            let mut data_file = NamedTempFile::new()?;
+            while let Some(data) = field.next().await {
+                match data {
+                    Ok(data) => {
+                        // Write the data to our file
+                        data_file.write_all(&data)?;
+                    }
+                    Err(e) => {
+                        return Err(Error::Multipart(e));
+                    }
+                }
+            }
+            // Put it in our data map so we can stick it in the report struct at the end
+            file_map.insert(String::from(field_name), data_file);
+        }
+        // If it's not an expected field, return an error
+        else {
+            // Return an error if there's a field we don't expect
+            return Err(Error::UnexpectedField(String::from(field_name)));
+        }
+    }
+    // Verify we have found all the required fields
+    check_for_required_fields(
+        required_text_fields,
+        required_file_fields,
+        &string_map,
+        &file_map,
+    )?;
+
+    Ok((string_map, file_map))
+}
+
+/// Header guard function for checking if the content type of a request head (`req`) is multipart
+///
+/// This is necessary (instead of just using `guard::Header("Content-Type","multipart/form-data")`)
+/// to account for the inclusion of the required boundary parameter in the header
+/// (e.g. `multipart/form-data;boundary="abcd"`)
+pub fn multipart_content_type_guard(req: &RequestHead) -> bool {
+    // Get the content type header from the request head
+    let content_type_header = match req.headers().get("content-type") {
+        Some(content_type) => content_type,
+        None => {
+            return false;
+        }
+    };
+    // Parse the header as a string
+    let content_type_string = match content_type_header.to_str() {
+        Ok(header_string) => String::from(header_string),
+        Err(e) => {
+            warn!(
+                "Failed to parse content-type header for request as string with error: {}",
+                e
+            );
+            return false;
+        }
+    };
+    // Check if the content type is multipart
+    content_type_string.starts_with("multipart/form-data")
+}
+
+/// Returns () if `string_map` contains all the keys in `required_text_fields` and `file_map`
+/// contains all the keys in `required_file_fields`.  Otherwise, returns an error
+fn check_for_required_fields(
+    required_text_fields: &Vec<&str>,
+    required_file_fields: &Vec<&str>,
+    string_map: &HashMap<String, String>,
+    file_map: &HashMap<String, NamedTempFile>,
+) -> Result<(), Error> {
+    // Loop through both lists of required fields and return an error if any are found to not be
+    // present in the maps we expect to find them in
+    for field in required_text_fields {
+        if !string_map.contains_key(*field) {
+            return Err(Error::MissingField(String::from(*field)));
+        }
+    }
+    for field in required_file_fields {
+        if !file_map.contains_key(*field) {
+            return Err(Error::MissingField(String::from(*field)));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use actix_multipart::Multipart;
+    use actix_web::dev::Service;
+    use actix_web::error::PayloadError;
+    use actix_web::http::{header, HeaderMap};
+    use actix_web::web::Bytes;
+    use futures_core::Stream;
+    use futures_util::{future::lazy, SinkExt, StreamExt};
+    use std::collections::HashMap;
+    use std::fs::read_to_string;
+    use tempfile::NamedTempFile;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    fn create_stream() -> (
+        mpsc::UnboundedSender<Result<Bytes, PayloadError>>,
+        impl Stream<Item = Result<Bytes, PayloadError>>,
+    ) {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        (
+            tx,
+            UnboundedReceiverStream::new(rx).map(|res| res.map_err(|_| panic!())),
+        )
+    }
+
+    /// Creates and returns and Multipart instance containing `contents`
+    ///
+    /// `contents` must be supplied in proper Multipart format, using
+    /// ---------------------------974767299852498929531610575 for the boundary value
+    ///
+    /// Adapted partially from the actix multipart test code here:
+    /// https://github.com/actix/actix-web/blob/HEAD/actix-multipart/src/server.rs#L1013
+    fn create_multipart_with_contents(contents: String) -> Multipart {
+        // Create unbounded channel for streaming multipart data
+        let (mut sender, receiver) = mpsc::unbounded_channel();
+        let payload = UnboundedReceiverStream::new(receiver)
+            .map(|res: Result<Bytes, PayloadError>| res.map_err(|_| panic!()));
+        // Convert contents to bytes
+        let bytes = Bytes::from(contents);
+        // Make a headermap for the multipart instance that has the correct content type
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static(
+                "multipart/form-data; boundary=\"---------------------------974767299852498929531610575\"",
+            ),
+        );
+        // Send the contents down the data channel
+        sender.send(Ok(bytes)).unwrap();
+        // Create and return the multipart instance
+        Multipart::new(&headers, payload)
+    }
+
+    #[actix_rt::test]
+    async fn extract_data_from_multipart_success() {
+        // Read formatted multipart body from test file
+        let multipart_body =
+            read_to_string("testdata/routes/multipart_handling/example_multipart.txt")
+                .unwrap()
+                // Multipart needs carriage returns to be read properly
+                .replace("\n", "\r\n");
+
+        // Create a multipart instance from it to parse
+        let mut multipart = create_multipart_with_contents(multipart_body);
+
+        // The fields we expect from the multipart payload
+        const EXPECTED_TEXT_FIELDS: [&'static str; 5] = [
+            "name",
+            "description",
+            "pipeline_id",
+            "created_by",
+            "eval_wdl",
+        ];
+        const EXPECTED_FILE_FIELDS: [&'static str; 2] = ["test_wdl_file", "eval_wdl_file"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_TEXT_FIELDS: [&'static str; 2] = ["name", "pipeline_id"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_FILE_FIELDS: [&'static str; 1] = ["test_wdl_file"];
+        // Parse the multipart data to extract the fields
+        let (mut string_map, mut file_map): (
+            HashMap<String, String>,
+            HashMap<String, NamedTempFile>,
+        ) = super::extract_data_from_multipart(
+            multipart,
+            &EXPECTED_TEXT_FIELDS.to_vec(),
+            &EXPECTED_FILE_FIELDS.to_vec(),
+            &REQUIRED_TEXT_FIELDS.to_vec(),
+            &REQUIRED_FILE_FIELDS.to_vec(),
+        )
+        .await
+        .unwrap();
+        // Check that we extracted all the data properly
+        let pipeline_id: String = string_map.remove("pipeline_id").unwrap();
+        assert_eq!(pipeline_id, "6361391c-96ee-4207-a371-e525f7d3f138");
+        let name: String = string_map.remove("name").unwrap();
+        assert_eq!(name, "Test template");
+        let description: String = string_map.remove("description").unwrap();
+        assert_eq!(
+            description,
+            "Template for testing multipart template creation"
+        );
+        let created_by: String = string_map.remove("created_by").unwrap();
+        assert_eq!(created_by, "Kevin@example.com");
+        let eval_wdl: String = string_map.remove("eval_wdl").unwrap();
+        assert_eq!(eval_wdl, "http://example.com/eval.wdl");
+        let test_wdl: String =
+            read_to_string(file_map.remove("test_wdl_file").unwrap().path()).unwrap();
+        assert_eq!(
+            test_wdl,
+            "workflow myWorkflow {\r\n    \
+                call myTask\r\n\
+            }\r\n\
+            \r\n\
+            task myTask {\r\n    \
+                command {\r\n        \
+                    echo \"hello world\"\r\n    \
+                }\r\n    \
+                output {\r\n        \
+                    String out = read_string(stdout())\r\n    \
+                }\r\n\
+            }"
+        );
+        // Make sure that was all that was read
+        assert!(string_map.is_empty());
+        assert!(file_map.is_empty());
+    }
+
+    #[actix_rt::test]
+    async fn extract_data_from_multipart_failure_missing_required() {
+        // Read formatted multipart body from test file
+        let multipart_body =
+            read_to_string("testdata/routes/multipart_handling/example_multipart.txt")
+                .unwrap()
+                // Multipart needs carriage returns to be read properly
+                .replace("\n", "\r\n");
+
+        // Create a multipart instance from it to parse
+        let mut multipart = create_multipart_with_contents(multipart_body);
+
+        // The fields we expect from the multipart payload
+        const EXPECTED_TEXT_FIELDS: [&'static str; 5] = [
+            "name",
+            "description",
+            "pipeline_id",
+            "created_by",
+            "eval_wdl",
+        ];
+        const EXPECTED_FILE_FIELDS: [&'static str; 2] = ["test_wdl_file", "eval_wdl_file"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_TEXT_FIELDS: [&'static str; 2] = ["name", "pipeline_id"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_FILE_FIELDS: [&'static str; 1] = ["eval_wdl_file"];
+        // Parse the multipart data to extract the fields
+        let error_result: super::Error = super::extract_data_from_multipart(
+            multipart,
+            &EXPECTED_TEXT_FIELDS.to_vec(),
+            &EXPECTED_FILE_FIELDS.to_vec(),
+            &REQUIRED_TEXT_FIELDS.to_vec(),
+            &REQUIRED_FILE_FIELDS.to_vec(),
+        )
+        .await
+        .unwrap_err();
+        // Check that we got the error we expected
+        let missing_field = String::from("eval_wdl_file");
+        assert!(matches!(
+            error_result,
+            super::Error::MissingField(missing_field)
+        ));
+    }
+
+    #[actix_rt::test]
+    async fn extract_data_from_multipart_failure_unexpected_field() {
+        // Read formatted multipart body from test file
+        let multipart_body =
+            read_to_string("testdata/routes/multipart_handling/example_multipart.txt")
+                .unwrap()
+                // Multipart needs carriage returns to be read properly
+                .replace("\n", "\r\n");
+
+        // Create a multipart instance from it to parse
+        let mut multipart = create_multipart_with_contents(multipart_body);
+
+        // The fields we expect from the multipart payload
+        const EXPECTED_TEXT_FIELDS: [&'static str; 4] =
+            ["description", "pipeline_id", "created_by", "eval_wdl"];
+        const EXPECTED_FILE_FIELDS: [&'static str; 2] = ["test_wdl_file", "eval_wdl_file"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_TEXT_FIELDS: [&'static str; 1] = ["pipeline_id"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_FILE_FIELDS: [&'static str; 1] = ["test_wdl_file"];
+        // Parse the multipart data to extract the fields
+        let error_result: super::Error = super::extract_data_from_multipart(
+            multipart,
+            &EXPECTED_TEXT_FIELDS.to_vec(),
+            &EXPECTED_FILE_FIELDS.to_vec(),
+            &REQUIRED_TEXT_FIELDS.to_vec(),
+            &REQUIRED_FILE_FIELDS.to_vec(),
+        )
+        .await
+        .unwrap_err();
+        // Check that we got the error we expected
+        let unexpected_field = String::from("name");
+        assert!(matches!(
+            error_result,
+            super::Error::UnexpectedField(unexpected_field)
+        ));
+    }
+
+    #[actix_rt::test]
+    async fn extract_data_from_multipart_failure_field_format() {
+        // Read formatted multipart body from test file
+        let multipart_body = String::from(
+            "-----------------------------974767299852498929531610575\r\n
+                Content-Disposition: form-data\r\n\r\n
+                6361391c-96ee-4207-a371-e525f7d3f138\r\n
+                -----------------------------974767299852498929531610575--",
+        );
+
+        // Create a multipart instance from it to parse
+        let mut multipart = create_multipart_with_contents(multipart_body);
+
+        // The fields we expect from the multipart payload
+        const EXPECTED_TEXT_FIELDS: [&'static str; 5] = [
+            "name",
+            "description",
+            "pipeline_id",
+            "created_by",
+            "eval_wdl",
+        ];
+        const EXPECTED_FILE_FIELDS: [&'static str; 2] = ["test_wdl_file", "eval_wdl_file"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_TEXT_FIELDS: [&'static str; 2] = ["name", "pipeline_id"];
+        // The fields that are required from the multipart payload
+        const REQUIRED_FILE_FIELDS: [&'static str; 1] = ["test_wdl_file"];
+        // Parse the multipart data to extract the fields
+        let error_result: super::Error = super::extract_data_from_multipart(
+            multipart,
+            &EXPECTED_TEXT_FIELDS.to_vec(),
+            &EXPECTED_FILE_FIELDS.to_vec(),
+            &REQUIRED_TEXT_FIELDS.to_vec(),
+            &REQUIRED_FILE_FIELDS.to_vec(),
+        )
+        .await
+        .unwrap_err();
+        // Check that we got the error we expected
+        assert!(matches!(error_result, super::Error::FieldFormat(_)));
+    }
+}

--- a/src/routes/run_report.rs
+++ b/src/routes/run_report.rs
@@ -766,7 +766,7 @@ mod tests {
             Some(gcloud_config) => {
                 let mut gcloud_client = GCloudClient::new(gcloud_config.gcloud_sa_key_file());
                 gcloud_client.set_upload_file(Box::new(
-                    |f: File,
+                    |f: &File,
                      address: &str,
                      name: &str|
                      -> Result<String, crate::storage::gcloud_storage::Error> {

--- a/src/routes/subscription.rs
+++ b/src/routes/subscription.rs
@@ -12,6 +12,7 @@ use crate::models::subscription::{
 use crate::models::template::TemplateData;
 use crate::models::test::TestData;
 use crate::routes::error_handling::{default_500, ErrorBody};
+use crate::routes::util::parse_id;
 use actix_web::{error::BlockingError, web, HttpResponse};
 use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
@@ -474,26 +475,6 @@ fn validate_email(email: &str) -> Result<(), HttpResponse> {
     }
 
     Ok(())
-}
-
-/// Attempts to parse `id` as a Uuid
-///
-/// Returns parsed `id` if successful, or an HttpResponse with an error message if it fails
-/// This function basically exists so I don't have to keep rewriting the error handling for
-/// parsing Uuid path variables and having that take up a bunch of space
-fn parse_id(id: &str) -> Result<Uuid, HttpResponse> {
-    match Uuid::parse_str(id) {
-        Ok(id) => return Ok(id),
-        Err(e) => {
-            error!("{}", e);
-            // If it doesn't parse successfully, return an error to the user
-            return Err(HttpResponse::BadRequest().json(ErrorBody {
-                title: "ID formatted incorrectly".to_string(),
-                status: 400,
-                detail: "ID must be formatted as a Uuid".to_string(),
-            }));
-        }
-    }
 }
 
 /// Verifies if a record with `id` of type `entity_type` exists in the DB

--- a/src/routes/util.rs
+++ b/src/routes/util.rs
@@ -1,0 +1,26 @@
+//! Contains utility functions shared by multiple of the modules within the `routes` module
+
+use crate::routes::error_handling::ErrorBody;
+use actix_web::HttpResponse;
+use log::error;
+use uuid::Uuid;
+
+/// Attempts to parse `id` as a Uuid
+///
+/// Returns parsed `id` if successful, or an HttpResponse with an error message if it fails
+/// This function basically exists so I don't have to keep rewriting the error handling for
+/// parsing Uuid path variables and having that take up a bunch of space
+pub fn parse_id(id: &str) -> Result<Uuid, HttpResponse> {
+    match Uuid::parse_str(id) {
+        Ok(id) => return Ok(id),
+        Err(e) => {
+            error!("{}", e);
+            // If it doesn't parse successfully, return an error to the user
+            return Err(HttpResponse::BadRequest().json(ErrorBody {
+                title: "ID formatted incorrectly".to_string(),
+                status: 400,
+                detail: "ID must be formatted as a Uuid".to_string(),
+            }));
+        }
+    }
+}

--- a/src/util/temp_storage.rs
+++ b/src/util/temp_storage.rs
@@ -8,10 +8,10 @@ use tempfile::NamedTempFile;
 ///
 /// Creates a NamedTempFile and writes `contents` to it.  Returns the file if successful.  Returns
 /// an error if creating or writing to the file fails
-pub fn get_temp_file(contents: &str) -> Result<NamedTempFile, std::io::Error> {
+pub fn get_temp_file(contents: &[u8]) -> Result<NamedTempFile, std::io::Error> {
     match NamedTempFile::new() {
         Ok(mut file) => {
-            if let Err(e) = write!(file, "{}", contents) {
+            if let Err(e) = file.write_all(contents) {
                 error!(
                     "Encountered error while attempting to write to temporary file: {}",
                     e

--- a/testdata/routes/multipart_handling/example_multipart.txt
+++ b/testdata/routes/multipart_handling/example_multipart.txt
@@ -1,0 +1,37 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="pipeline_id"
+
+6361391c-96ee-4207-a371-e525f7d3f138
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Test template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Template for testing multipart template creation
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="created_by"
+
+Kevin@example.com
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl_file"; filename="test.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call myTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl"
+
+http://example.com/eval.wdl
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/invalid_create_multipart_duplicate_name.txt
+++ b/testdata/routes/template/invalid_create_multipart_duplicate_name.txt
@@ -1,0 +1,49 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="pipeline_id"
+
+{pipeline_id}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Kevin's Template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Template for testing multipart template creation
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="created_by"
+
+Kevin@example.com
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl_file"; filename="test.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call myTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl_file"; filename="eval.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myOtherWorkflow {
+    call myOtherTask
+}
+
+task myOtherTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/invalid_create_multipart_invalid_wdl.txt
+++ b/testdata/routes/template/invalid_create_multipart_invalid_wdl.txt
@@ -1,0 +1,38 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="pipeline_id"
+
+{pipeline_id}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Test template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Template for testing multipart template creation
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="created_by"
+
+Kevin@example.com
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl_file"; filename="test.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call wrongTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl"
+Content-Type: text/plain; charset=UTF-8
+
+{eval_wdl_location}
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/invalid_update_multipart_invalid_wdl.txt
+++ b/testdata/routes/template/invalid_update_multipart_invalid_wdl.txt
@@ -1,0 +1,30 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Updated template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Updated description for updated template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl"
+Content-Type: text/plain; charset=UTF-8
+
+{test_wdl_location}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl_file"; filename="eval.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call wrongTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/valid_create_multipart.txt
+++ b/testdata/routes/template/valid_create_multipart.txt
@@ -1,0 +1,49 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="pipeline_id"
+
+{pipeline_id}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Test template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Template for testing multipart template creation
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="created_by"
+
+Kevin@example.com
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl_file"; filename="test.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call myTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl_file"; filename="eval.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myOtherWorkflow {
+    call myOtherTask
+}
+
+task myOtherTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/valid_create_multipart_one_wdl_uploaded_one_wdl_linked.txt
+++ b/testdata/routes/template/valid_create_multipart_one_wdl_uploaded_one_wdl_linked.txt
@@ -1,0 +1,38 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="pipeline_id"
+
+{pipeline_id}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Test template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Template for testing multipart template creation
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="created_by"
+
+Kevin@example.com
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl_file"; filename="test.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call myTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl"
+Content-Type: text/plain; charset=UTF-8
+
+{eval_wdl_location}
+-----------------------------974767299852498929531610575--

--- a/testdata/routes/template/valid_update_multipart.txt
+++ b/testdata/routes/template/valid_update_multipart.txt
@@ -1,0 +1,30 @@
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="name"
+
+Updated template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="description"
+
+Updated description for updated template
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="test_wdl"
+Content-Type: text/plain; charset=UTF-8
+
+{test_wdl_location}
+-----------------------------974767299852498929531610575
+Content-Disposition: form-data; name="eval_wdl_file"; filename="eval.wdl"
+Content-Type: text/plain; charset=UTF-8
+
+workflow myWorkflow {
+    call myTask
+}
+
+task myTask {
+    command {
+        echo "hello world"
+    }
+    output {
+        String out = read_string(stdout())
+    }
+}
+-----------------------------974767299852498929531610575--


### PR DESCRIPTION
Added a module for parsing multipart data.  That module is being used to process data from two new template route mappings for create and update.  This allows the option of uploading the test and/or eval wdl instead of only being able to link to them from places where they are hosted elsewhere.