### PR TITLE
Fixed an issue causing report building from the REST API to fail

### DIFF
--- a/src/routes/run_report.rs
+++ b/src/routes/run_report.rs
@@ -188,7 +188,7 @@ async fn create(
     web::Json(run_report_inputs): web::Json<NewRunReportIncomplete>,
     query_params: Query<CreateQueryParams>,
     pool: web::Data<db::DbPool>,
-    report_builder: web::Data<ReportBuilder>,
+    report_builder: web::Data<Option<ReportBuilder>>,
 ) -> Result<HttpResponse, actix_web::Error> {
     // Pull id params from path
     let id = &req.match_info().get("id").unwrap();
@@ -226,17 +226,29 @@ async fn create(
     };
     // Get DB connection
     let conn = pool.get().expect("Failed to get DB connection from pool");
-    // Create run report
-    match report_builder
-        .create_run_report(
-            &conn,
-            id,
-            report_id,
-            &run_report_inputs.created_by,
-            delete_failed,
-        )
-        .await
-    {
+    // Get the report_builder and create the run report or return an error if we don't have one
+    match {
+        match report_builder.as_ref() {
+            Some(report_builder) => {
+                report_builder
+                    .create_run_report(
+                        &conn,
+                        id,
+                        report_id,
+                        &run_report_inputs.created_by,
+                        delete_failed,
+                    )
+                    .await
+            },
+            None => {
+                return Ok(HttpResponse::InternalServerError().json(ErrorBody{
+                    title: String::from("No report builder"),
+                    status: 500,
+                    detail: String::from("Reporting is configured but no report builder was constructed.  This is a bug.  Please complain about it on the carrot github.")
+                }))
+            }
+        }
+    } {
         Ok(run_report) => Ok(HttpResponse::Ok().json(run_report)),
         Err(err) => {
             error!("{}", err);
@@ -789,7 +801,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -845,7 +857,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_disabled),
         )
         .await;
@@ -892,7 +904,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -947,7 +959,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -992,7 +1004,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -1036,7 +1048,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -1081,7 +1093,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;
@@ -1130,7 +1142,7 @@ mod tests {
         let mut app = test::init_service(
             App::new()
                 .data(pool)
-                .data(test_report_builder)
+                .data(Some(test_report_builder))
                 .configure(init_routes_reporting_enabled),
         )
         .await;

--- a/src/routes/run_report.rs
+++ b/src/routes/run_report.rs
@@ -244,7 +244,12 @@ async fn create(
                 return Ok(HttpResponse::InternalServerError().json(ErrorBody{
                     title: String::from("No report builder"),
                     status: 500,
-                    detail: String::from("Reporting is configured but no report builder was constructed.  This is a bug.  Please complain about it on the carrot github.")
+                    detail: String::from(
+                        "Reporting is configured but no report builder was constructed.  \
+                          This is a bug.  \
+                          Please complain about it on the carrot github: \
+                          https://github.com/broadinstitute/carrot/issues"
+                    )
                 }))
             }
         }


### PR DESCRIPTION
The actix app was configured to have an Option<ReportBuilder> (since it's possible that the user did not want to enable reporting functionality) but, where it was being used, it wasn't accounting for that fact that it was an option.