### PR TITLE
Clickable links in github comments plus some formatting improvements

### DIFF
--- a/src/requests/test_resource_requests.rs
+++ b/src/requests/test_resource_requests.rs
@@ -9,6 +9,7 @@ use actix_web::client::Client;
 use std::fmt;
 use std::fs::{read, read_to_string};
 use std::str::Utf8Error;
+use crate::util::gs_uri_parsing;
 
 /// Struct for handling retrieving test data from http, gcs, and local locations
 #[derive(Clone)]
@@ -96,7 +97,7 @@ impl TestResourceClient {
     pub async fn get_resource_as_bytes(&self, address: &str) -> Result<Vec<u8>, Error> {
         // If the address is a gs address and retrieving from gs addresses is enabled, retrieve the data
         // using the gcloud storage api
-        if self.gcs_client.is_some() && address.starts_with(gcloud_storage::GS_URI_PREFIX) {
+        if self.gcs_client.is_some() && address.starts_with(gs_uri_parsing::GS_URI_PREFIX) {
             // We already know gcs_client has a value, so we can expect it
             let gcs_client = self.gcs_client.as_ref().expect("Attempted to unwrap TestResourceClient's gcs_client but failed.  This should not happen.");
             Ok(gcs_client

--- a/src/util/gs_uri_parsing.rs
+++ b/src/util/gs_uri_parsing.rs
@@ -1,0 +1,108 @@
+//! Provides functions for parsing gs uris and related operations
+
+use std::fmt;
+use percent_encoding::{AsciiSet, CONTROLS};
+
+/// Prefix indicating a URI is a GS URI
+pub static GS_URI_PREFIX: &'static str = "gs://";
+
+/// A set of all the characters that need to be percent-encoded for the GCS API
+pub const GCLOUD_ENCODING_SET: &AsciiSet = &CONTROLS
+    .add(b'!')
+    .add(b'#')
+    .add(b'$')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'=')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b']')
+    .add(b' ');
+
+#[derive(Debug)]
+pub enum Error {
+    Parse(String)
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Parse(e) => write!(f, "GS URI Parsing Error Parsing URI {}", e),
+        }
+    }
+}
+
+/// Extracts the bucket name and the object name from the full gs uri of a file.  Expects
+/// `object_uri` in the format gs://bucketname/ob/ject/nam/e
+pub fn parse_bucket_and_object_name(object_uri: &str) -> Result<(String, String), Error> {
+    // Split it so we can extract the parts we want
+    let split_result_uri: Vec<&str> = object_uri.split("/").collect();
+    // If the split uri isn't at least 4 parts, this isn't a valid uri
+    if split_result_uri.len() < 4 {
+        return Err(Error::Parse(format!(
+            "Failed to split uri into bucket and object names {}",
+            object_uri
+        )));
+    }
+    // Bucket name comes after the gs://
+    let bucket_name = String::from(split_result_uri[2]);
+    // Object name is everything after the bucket name
+    let object_name = String::from(object_uri.splitn(4, "/").collect::<Vec<&str>>()[3]);
+    Ok((bucket_name, object_name))
+}
+
+/// Parses the provided gs `object_uri` and converts it into the equivalent cloud console url
+pub fn get_object_cloud_console_url_from_gs_uri(object_uri: &str) -> Result<String, Error> {
+    // First, get object and bucket name from uri
+    let (bucket_name, object_name) = parse_bucket_and_object_name(object_uri)?;
+    // Now create and return the formatted console url
+    Ok(format!(
+        "https://console.cloud.google.com/storage/browser/_details/{}/{}",
+        percent_encoding::utf8_percent_encode(&bucket_name, GCLOUD_ENCODING_SET),
+        percent_encoding::utf8_percent_encode(&object_name, GCLOUD_ENCODING_SET)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bucket_and_object_name_success() {
+        let test_result_uri = "gs://bucket_name/some/garbage/filename.txt";
+        let (bucket_name, object_name) = parse_bucket_and_object_name(test_result_uri).unwrap();
+        assert_eq!(bucket_name, "bucket_name");
+        assert_eq!(object_name, "some/garbage/filename.txt");
+    }
+
+    #[test]
+    fn parse_bucket_and_object_name_failure_too_short() {
+        let test_result_uri = "gs://filename.txt";
+        let failure = parse_bucket_and_object_name(test_result_uri);
+        assert!(matches!(failure, Err(Error::Parse(_))));
+    }
+
+    #[test]
+    fn get_object_cloud_console_url_from_gs_uri_success() {
+        let test_result_uri = "gs://bucket_name/some/garbage/filename.txt";
+        let console_url = get_object_cloud_console_url_from_gs_uri(test_result_uri).unwrap();
+        assert_eq!(console_url, "https://console.cloud.google.com/storage/browser/_details/bucket_name/some%2Fgarbage%2Ffilename.txt");
+    }
+
+    #[test]
+    fn get_object_cloud_console_url_from_gs_uri_failure_too_short() {
+        let test_result_uri = "gs://filename.txt";
+        let failure = get_object_cloud_console_url_from_gs_uri(test_result_uri);
+        assert!(matches!(failure, Err(Error::Parse(_))));
+    }
+
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
 //! Contains modules with functionality that is used elsewhere but that I can't find a better home
 //! for
 pub mod git_repos;
+pub mod gs_uri_parsing;
 pub mod python_dict_formatter;
 pub mod sort_string;
 pub mod temp_storage;

--- a/src/util/wdl_storage.rs
+++ b/src/util/wdl_storage.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io::prelude::*;
 use std::path::PathBuf;
 use uuid::Uuid;
+use crate::util::gs_uri_parsing;
 
 #[derive(Debug)]
 pub enum Error {
@@ -167,7 +168,7 @@ impl WdlStorageClient {
         // Loop through the results, and check if there is a result that matches the current scheme
         // we're using for wdl storage (local or GCS).  Return it, if so.  Otherwise, return None
         for wdl_hash in existing_wdl_hashes {
-            if wdl_hash.location.starts_with(gcloud_storage::GS_URI_PREFIX) {
+            if wdl_hash.location.starts_with(gs_uri_parsing::GS_URI_PREFIX) {
                 if self.config.is_gcs() {
                     return Ok(Some(wdl_hash.location.to_owned()));
                 }


### PR DESCRIPTION
Modified the format of comments to github to be slightly more organized and to include clickable links to the gcloud console for file results.

Full JSON details for a run are now in an expandable section that is collapsed by default:

![Screen Shot 2022-04-25 at 10 07 48 AM](https://user-images.githubusercontent.com/8883228/165107464-fb992a71-01a9-46f6-9e17-2c0afefdf3b6.png)

Expanded:

![Screen Shot 2022-04-25 at 10 07 58 AM](https://user-images.githubusercontent.com/8883228/165107571-ff42ef8b-56cd-4efa-abea-45cb5ae7e1c3.png)

Success messages contain expandable sections for the full details JSON and a table of results with clickable links to the GCS console for any file results:

![Screen Shot 2022-04-25 at 10 08 12 AM](https://user-images.githubusercontent.com/8883228/165108079-84dc974e-5c78-4d88-9e69-c0999712fdb4.png)

Expanded:

![Screen Shot 2022-04-25 at 10 08 24 AM](https://user-images.githubusercontent.com/8883228/165108161-1a2219f4-5c6b-42ca-bc5c-509159f16d49.png)

Success messages for reports now also include clickable links:

![Screen Shot 2022-04-25 at 10 08 32 AM](https://user-images.githubusercontent.com/8883228/165108292-44c4dbdb-8c15-48fb-a263-637ad84e3236.png)