### PR TITLE
Added the ability to download run data CSV zip files

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -452,33 +452,22 @@ Only certain python libraries are currently supported within the CARROT reportin
 ```
 
 
+###### <a name="1d-using-data-from-carrot"/> **1c. Using data from CARROT**
 
-###### <a name="1c-a-control-block-optional"/> **1c. A control block (optional)**
+When the report is generated, CARROT will supply the data for the run(s) in a series of CSV files that should be opened within your Jupyter Notebook in order to access the data.  The following CSV files will be included:
 
-The control block is a Jupyter notebook cell at the top of a notebook that contains directives for CARROT indicating how to execute the notebook.  It is an optional section and may be omitted.
+* metadata.csv - contains a row for each run with metadata for that row (rund_id, name, test_id, status, cromwell ids, created_at, created_by, finished_at, and errors)
+* test_inputs.csv - contains a row for each run with its run id and the contents of the test_input json for that run, with input names as column headers
+* eval_inputs.csv - contains a row for each run with its run id and the contents of the eval_input json for that run, with input names as column headers
+* test_options.csv - contains a row for each run with its run id and the contents of the test_options json for that run, with option names as column headers
+* eval_options.csv - contains a row for each run with its run id and the contents of the eval_options json for that run, with option names as column headers
+* results.csv - contains a row for each run with its run id and the contents of the results json for that run, with the result names as column headers
 
-By default, the job that generates a report will download all the result files for the run associated to the report being generated (it will not download any inputs).  If you would like to override this behavior (e.g. to  download the workflow inputs to use as part of the notebook visualization and to not download the results), you can do so by including a control block at the top of your notebook that looks like this:
+If you would like to download these files to use them locally and experiment with your notebook definition before defining the Report in CARROT, you can use the `--zip_csv` option in any of the `find_runs` commands or the `run find_by_id` command in carrot_cli.  For example:
 
-![Report Control Block](images/Report_Control_Block.png)
-
-
-Currently these parameters are only allowed to be set within a control block.
-
-The `carrot_download_results `parameter determines whether result files will be downloaded automatically (defaults to `True`).
-
-The `carrot_download_inputs `parameter determines whether input files will be downloaded automatically.  Automatic downloading is currently limited to only files indicated by `gs://` URIs.
-
-
-###### <a name="1d-using-data-from-carrot"/> **1d. Using data from CARROT**
-
-When generating the report, CARROT will insert a cell at the top containing a Python dictionary with the data for the run for which the report is being generated.  This dictionary will be formatted to match the value you would get if you were to retrieve a run’s data using `carrot_cli run find_by_id.`
-
-![Example Run Data Block](images/Example_Run_Data.png)
-
-
-The dictionary is titled `carrot_run_data`.  You can reference this variable within your notebook to use any of this data within your report.  If you allow automatic downloading of the `gs://` files within the notebook, they will be stored in a dictionary called `carrot_downloads`.  For example, if you enable automatic downloading of result files, you will be able to access the result titled “<code><em>Output File</em></code>” in the example above via:
-
-`carrot_downloads['results']['Output File']`
+```
+carrot_cli tempalte find_runs "My cool template" --zip_csv run_data_csvs.zip
+```
 
 
 ##### <a name="2-define-a-report-in-carrot"/> **2. Define a Report in CARROT**

--- a/carrot_cli/src/carrot_cli/file_util.py
+++ b/carrot_cli/src/carrot_cli/file_util.py
@@ -28,3 +28,19 @@ def read_file_to_json(filename):
             sys.exit(1)
     else:
         return ""
+
+def write_data_to_file(data, filename):
+    """
+    Writes data to the file specified by filename
+    :param data: bytes to write to file
+    :param filename: filename to write to
+    """
+    try:
+        with open(filename, "w+b") as data_file:
+            data_file.write(data)
+    except IOError as e:
+        LOGGER.error(
+            f"Encountered the following error while trying to write data to file {filename}: {e}"
+        )
+        sys.exit(1)
+

--- a/carrot_cli/src/carrot_cli/pipeline/command.py
+++ b/carrot_cli/src/carrot_cli/pipeline/command.py
@@ -225,6 +225,12 @@ def delete(pipeline, yes):
     "asc(created_at) with offset=1 would return records sorted by when they were created "
     "starting from the second record to be created",
 )
+@click.option(
+    "--zip_csv",
+    "--instead_of_json_give_me_a_zipped_folder_with_csvs_in_it_please_and_thank_you",
+    type=click.Path(),
+    help="Instead of writing results to stdout as JSON, writes as a zip of CSV files to the specified file"
+)
 def find_runs(
     pipeline,
     name,
@@ -243,6 +249,7 @@ def find_runs(
     sort,
     limit,
     offset,
+    zip_csv
 ):
     """
     Retrieve runs related to the pipeline specified by PIPELINE (id or name), filtered by the
@@ -275,6 +282,7 @@ def find_runs(
             sort,
             limit,
             offset,
+            csv=zip_csv
         )
     )
 

--- a/carrot_cli/src/carrot_cli/rest/runs.py
+++ b/carrot_cli/src/carrot_cli/rest/runs.py
@@ -1,13 +1,23 @@
 import logging
 
 from . import request_handler
+from .. import file_util
 
 LOGGER = logging.getLogger(__name__)
 
 
-def find_by_id(run_id):
-    """Submits a request to CARROT's runs find_by_id mapping"""
-    return request_handler.find_by_id("runs", run_id)
+def find_by_id(run_id, csv=None):
+    """
+    Submits a request to CARROT's runs find_by_id mapping. If csv is specified as true, the request
+    will include a query param called 'csv' set to true
+    """
+    if csv is not None:
+        # Write to file
+        csv_data = request_handler.find_by_id("runs", run_id, params=[("csv", "true")], expected_format=request_handler.ResponseFormat.BYTES)
+        file_util.write_data_to_file(csv_data, csv)
+        return "Success!"
+    else:
+        return request_handler.find_by_id("runs", run_id)
 
 
 def find(
@@ -29,6 +39,7 @@ def find(
     sort="",
     limit="",
     offset="",
+    csv=None
 ):
     """
     Submits a request to CARROT's find runs mapping for the specfied parent_entity (pipeline,
@@ -52,7 +63,16 @@ def find(
         ("sort", sort),
         ("limit", limit),
         ("offset", offset),
+        ("csv", str(csv is not None).lower())
     ]
+    # If csv is true, we want to specify that we're expecting the result as a file (bytes)
+    if csv is not None:
+        # Write to file
+        csv_data = request_handler.find_runs(
+            parent_entity, parent_entity_id, params, expected_format=request_handler.ResponseFormat.BYTES
+        )
+        file_util.write_data_to_file(csv_data, csv)
+        return "Success!"
     return request_handler.find_runs(parent_entity, parent_entity_id, params)
 
 

--- a/carrot_cli/src/carrot_cli/run/command.py
+++ b/carrot_cli/src/carrot_cli/run/command.py
@@ -20,9 +20,15 @@ def main():
 
 @main.command(name="find_by_id")
 @click.argument("id")
-def find_by_id(id):
+@click.option(
+    "--zip_csv",
+    "--instead_of_json_give_me_a_zipped_folder_with_csvs_in_it_please_and_thank_you",
+    type=click.Path(),
+    help="Instead of writing results to stdout as JSON, writes as a zip of CSV files to the specified file"
+)
+def find_by_id(id, zip_csv=None):
     """Retrieve a run by its ID"""
-    print(runs.find_by_id(id))
+    print(runs.find_by_id(id, csv=zip_csv))
 
 
 @main.command(name="delete")

--- a/carrot_cli/src/carrot_cli/template/command.py
+++ b/carrot_cli/src/carrot_cli/template/command.py
@@ -337,6 +337,12 @@ def delete(template, yes):
     "asc(created_at) with offset=1 would return records sorted by when they were created "
     "starting from the second record to be created",
 )
+@click.option(
+    "--zip_csv",
+    "--instead_of_json_give_me_a_zipped_folder_with_csvs_in_it_please_and_thank_you",
+    type=click.Path(),
+    help="Instead of writing results to stdout as JSON, writes as a zip of CSV files to the specified file"
+)
 def find_runs(
     template,
     name,
@@ -355,6 +361,7 @@ def find_runs(
     sort,
     limit,
     offset,
+    zip_csv
 ):
     """
     Retrieve runs related to the template specified by TEMPLATE (id or name), filtered by the
@@ -389,6 +396,7 @@ def find_runs(
             sort,
             limit,
             offset,
+            csv=zip_csv
         )
     )
 

--- a/carrot_cli/src/carrot_cli/test/command.py
+++ b/carrot_cli/src/carrot_cli/test/command.py
@@ -417,6 +417,12 @@ def run(test, name, test_input, test_options, eval_input, eval_options, created_
     "asc(created_at) with offset=1 would return records sorted by when they were created "
     "starting from the second record to be created",
 )
+@click.option(
+    "--zip_csv",
+    "--instead_of_json_give_me_a_zipped_folder_with_csvs_in_it_please_and_thank_you",
+    type=click.Path(),
+    help="Instead of writing results to stdout as JSON, writes as a zip of CSV files to the specified file"
+)
 def find_runs(
     test,
     name,
@@ -435,6 +441,7 @@ def find_runs(
     sort,
     limit,
     offset,
+    zip_csv
 ):
     """Retrieve runs of the test specified by TEST (id or name), filtered by the specified parameters"""
     # Process test to get id if it's a name
@@ -464,6 +471,7 @@ def find_runs(
             sort,
             limit,
             offset,
+            csv=zip_csv
         )
     )
 

--- a/carrot_cli/tests/unit/pipeline/test_pipeline_command.py
+++ b/carrot_cli/tests/unit/pipeline/test_pipeline_command.py
@@ -600,6 +600,7 @@ def test_delete(delete_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None
             ],
             "return": json.dumps(
                 [
@@ -623,6 +624,68 @@ def test_delete(delete_data, caplog):
                 indent=4,
                 sort_keys=True,
             ),
+        },
+        {
+            "args": [
+                "pipeline",
+                "find_runs",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "--name",
+                "Queen of Bright Moon run",
+                "--status",
+                "succeeded",
+                "--test_input",
+                "tests/data/mock_test_input.json",
+                "--test_options",
+                "tests/data/mock_test_options.json",
+                "--eval_input",
+                "tests/data/mock_eval_input.json",
+                "--eval_options",
+                "tests/data/mock_eval_options.json",
+                "--test_cromwell_job_id",
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "--eval_cromwell_job_id",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "--created_before",
+                "2020-10-00T00:00:00.000000",
+                "--created_after",
+                "2020-09-00T00:00:00.000000",
+                "--created_by",
+                "glimmer@example.com",
+                "--finished_before",
+                "2020-10-00T00:00:00.000000",
+                "--finished_after",
+                "2020-09-00T00:00:00.000000",
+                "--sort",
+                "asc(name)",
+                "--limit",
+                1,
+                "--offset",
+                0,
+                "--zip_csv",
+                "csvs.zip"
+            ],
+            "params": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "Queen of Bright Moon run",
+                "succeeded",
+                {"in_greeted": "Cool Person"},
+                {"option": "other_value"},
+                {"in_output_filename": "test_greeting.txt"},
+                {"option": "value"},
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "glimmer@example.com",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "asc(name)",
+                1,
+                0,
+                "csvs.zip"
+            ],
+            "return": "Success!"
         },
         {
             "args": [
@@ -680,6 +743,7 @@ def test_delete(delete_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None
             ],
             "from_name": {
                 "name": "Sword of Protection pipeline",
@@ -740,6 +804,7 @@ def test_delete(delete_data, caplog):
                 "",
                 20,
                 0,
+                None,
             ],
             "return": json.dumps(
                 {
@@ -795,6 +860,7 @@ def find_runs_data(request):
             request.param["params"][14],
             request.param["params"][15],
             request.param["params"][16],
+            csv=request.param["params"][17],
         ).thenReturn(request.param["return"])
     return request.param
 

--- a/carrot_cli/tests/unit/run/test_run_command.py
+++ b/carrot_cli/tests/unit/run/test_run_command.py
@@ -24,6 +24,7 @@ def no_email():
     params=[
         {
             "args": ["run", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "csv": None,
             "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
@@ -45,6 +46,7 @@ def no_email():
         },
         {
             "args": ["run", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "csv": None,
             "return": json.dumps(
                 {
                     "title": "No run found",
@@ -55,13 +57,18 @@ def no_email():
                 sort_keys=True,
             ),
         },
+        {
+            "args": ["run", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819", "--zip_csv", "csvs.zip"],
+            "csv": "csvs.zip",
+            "return": "Success!"
+        },
     ]
 )
 def find_by_id_data(request):
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(runs).find_by_id(...).thenReturn(None)
     # Mock up request response
-    mockito.when(runs).find_by_id(request.param["args"][2]).thenReturn(
+    mockito.when(runs).find_by_id(request.param["args"][2], csv=request.param["csv"]).thenReturn(
         request.param["return"]
     )
     return request.param

--- a/carrot_cli/tests/unit/template/test_template_command.py
+++ b/carrot_cli/tests/unit/template/test_template_command.py
@@ -878,6 +878,7 @@ def test_delete(delete_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None
             ],
             "return": json.dumps(
                 [
@@ -901,6 +902,68 @@ def test_delete(delete_data, caplog):
                 indent=4,
                 sort_keys=True,
             ),
+        },
+        {
+            "args": [
+                "template",
+                "find_runs",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "--name",
+                "Queen of Bright Moon run",
+                "--status",
+                "succeeded",
+                "--test_input",
+                "tests/data/mock_test_input.json",
+                "--test_options",
+                "tests/data/mock_test_options.json",
+                "--eval_input",
+                "tests/data/mock_eval_input.json",
+                "--eval_options",
+                "tests/data/mock_eval_options.json",
+                "--test_cromwell_job_id",
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "--eval_cromwell_job_id",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "--created_before",
+                "2020-10-00T00:00:00.000000",
+                "--created_after",
+                "2020-09-00T00:00:00.000000",
+                "--created_by",
+                "glimmer@example.com",
+                "--finished_before",
+                "2020-10-00T00:00:00.000000",
+                "--finished_after",
+                "2020-09-00T00:00:00.000000",
+                "--sort",
+                "asc(name)",
+                "--limit",
+                1,
+                "--offset",
+                0,
+                "--zip_csv",
+                "csvs.zip"
+            ],
+            "params": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "Queen of Bright Moon run",
+                "succeeded",
+                {"in_greeted": "Cool Person"},
+                {"option": "other_value"},
+                {"in_output_filename": "test_greeting.txt"},
+                {"option": "value"},
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "glimmer@example.com",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "asc(name)",
+                1,
+                0,
+                "csvs.zip",
+            ],
+            "return": "Success!"
         },
         {
             "args": [
@@ -958,6 +1021,7 @@ def test_delete(delete_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None
             ],
             "from_name": {
                 "name": "Sword of Protection template",
@@ -1021,6 +1085,7 @@ def test_delete(delete_data, caplog):
                 "",
                 20,
                 0,
+                None,
             ],
             "return": json.dumps(
                 {
@@ -1076,6 +1141,7 @@ def find_runs_data(request):
             request.param["params"][14],
             request.param["params"][15],
             request.param["params"][16],
+            csv=request.param["params"][17],
         ).thenReturn(request.param["return"])
     return request.param
 

--- a/carrot_cli/tests/unit/test/test_test_command.py
+++ b/carrot_cli/tests/unit/test/test_test_command.py
@@ -1119,6 +1119,7 @@ def test_run(run_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None,
             ],
             "return": json.dumps(
                 [
@@ -1142,6 +1143,68 @@ def test_run(run_data, caplog):
                 indent=4,
                 sort_keys=True,
             ),
+        },
+        {
+            "args": [
+                "test",
+                "find_runs",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "--name",
+                "Queen of Bright Moon run",
+                "--status",
+                "succeeded",
+                "--test_input",
+                "tests/data/mock_test_input.json",
+                "--test_options",
+                "tests/data/mock_test_options.json",
+                "--eval_input",
+                "tests/data/mock_eval_input.json",
+                "--eval_options",
+                "tests/data/mock_eval_options.json",
+                "--test_cromwell_job_id",
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "--eval_cromwell_job_id",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "--created_before",
+                "2020-10-00T00:00:00.000000",
+                "--created_after",
+                "2020-09-00T00:00:00.000000",
+                "--created_by",
+                "glimmer@example.com",
+                "--finished_before",
+                "2020-10-00T00:00:00.000000",
+                "--finished_after",
+                "2020-09-00T00:00:00.000000",
+                "--sort",
+                "asc(name)",
+                "--limit",
+                1,
+                "--offset",
+                0,
+                "--zip_csv",
+                "csvs.zip"
+            ],
+            "params": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "Queen of Bright Moon run",
+                "succeeded",
+                {"in_greeted": "Cool Person"},
+                {"option": "other_value"},
+                {"in_output_filename": "test_greeting.txt"},
+                {"option": "value"},
+                "d9855002-6b71-429c-a4de-8e90222488cd",
+                "03958293-6b71-429c-a4de-8e90222488cd",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "glimmer@example.com",
+                "2020-10-00T00:00:00.000000",
+                "2020-09-00T00:00:00.000000",
+                "asc(name)",
+                1,
+                0,
+                "csvs.zip",
+            ],
+            "return": "Success!",
         },
         {
             "args": [
@@ -1199,6 +1262,7 @@ def test_run(run_data, caplog):
                 "asc(name)",
                 1,
                 0,
+                None
             ],
             "from_name": {
                 "name": "New Sword of Protection test",
@@ -1262,6 +1326,7 @@ def test_run(run_data, caplog):
                 "",
                 20,
                 0,
+                None,
             ],
             "return": json.dumps(
                 {
@@ -1317,6 +1382,7 @@ def find_runs_data(request):
             request.param["params"][14],
             request.param["params"][15],
             request.param["params"][16],
+            csv=request.param["params"][17],
         ).thenReturn(request.param["return"])
     return request.param
 

--- a/src/manager/notification_handler.rs
+++ b/src/manager/notification_handler.rs
@@ -182,7 +182,13 @@ impl NotificationHandler {
         match &self.github_commenter {
             Some(github_commenter) => {
                 github_commenter
-                    .post_run_failed_to_start_comment(owner, repo, issue_number, error_message, test_name)
+                    .post_run_failed_to_start_comment(
+                        owner,
+                        repo,
+                        issue_number,
+                        error_message,
+                        test_name,
+                    )
                     .await?;
             }
             None => {}

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -1093,7 +1093,12 @@ impl StatusManager {
         let mut run_report_outputs_map: Map<String, Value> = Map::new();
         // Loop through the four outputs we want, get them from `outputs`, and put them in our outputs
         // map
-        for output_key in vec!["populated_notebook", "html_report", "empty_notebook", "run_csv_zip"] {
+        for output_key in vec![
+            "populated_notebook",
+            "html_report",
+            "empty_notebook",
+            "run_csv_zip",
+        ] {
             // Get the output from the cromwell outputs
             let output_val =
                 match outputs.get(&format!("generate_report_file_workflow.{}", output_key)) {

--- a/src/requests/test_resource_requests.rs
+++ b/src/requests/test_resource_requests.rs
@@ -5,11 +5,11 @@
 
 use crate::storage::gcloud_storage;
 use crate::storage::gcloud_storage::GCloudClient;
+use crate::util::gs_uri_parsing;
 use actix_web::client::Client;
 use std::fmt;
 use std::fs::read;
 use std::str::Utf8Error;
-use crate::util::gs_uri_parsing;
 
 /// Struct for handling retrieving test data from http, gcs, and local locations
 #[derive(Clone)]

--- a/src/routes/template.rs
+++ b/src/routes/template.rs
@@ -14,11 +14,12 @@ use crate::routes::error_handling::{default_500, ErrorBody};
 use crate::routes::multipart_handling;
 use crate::routes::util::parse_id;
 use crate::storage::gcloud_storage;
+use crate::util::gs_uri_parsing;
 use crate::util::wdl_storage::WdlStorageClient;
 use crate::validation::womtool;
 use crate::validation::womtool::WomtoolRunner;
 use actix_multipart::Multipart;
-use actix_web::{error::BlockingError, guard, HttpRequest, HttpResponse, Responder, web};
+use actix_web::{error::BlockingError, guard, web, HttpRequest, HttpResponse, Responder};
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::PgConnection;
 use log::{debug, error};
@@ -29,7 +30,6 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use tempfile::{NamedTempFile, TempDir};
 use uuid::Uuid;
-use crate::util::gs_uri_parsing;
 
 /// Enum for distinguishing between a template's test and eval wdl for consolidating functionality
 /// where the only difference is whether we're using the test or eval wdl
@@ -1783,7 +1783,7 @@ mod tests {
     use crate::unit_test_util::*;
     use actix_web::client::Client;
     use actix_web::web::Bytes;
-    use actix_web::{App, http, test};
+    use actix_web::{http, test, App};
     use chrono::Utc;
     use diesel::PgConnection;
     use mockito::Mock;

--- a/src/storage/gcloud_storage.rs
+++ b/src/storage/gcloud_storage.rs
@@ -1,4 +1,6 @@
 //! Defines functionality for interacting with the google cloud storage API
+use crate::util::gs_uri_parsing;
+use crate::util::gs_uri_parsing::GCLOUD_ENCODING_SET;
 use google_storage1::{Object, Storage};
 use hyper::client::Response;
 use percent_encoding::{AsciiSet, CONTROLS};
@@ -6,8 +8,6 @@ use std::fmt;
 use std::fs::File;
 use std::io::{Cursor, Read};
 use std::sync::{Arc, Mutex};
-use crate::util::gs_uri_parsing;
-use crate::util::gs_uri_parsing::GCLOUD_ENCODING_SET;
 
 /// Shorthand type for google_storage1::Storage<hyper::Client, yup_oauth2::ServiceAccountAccess<hyper::Client>>
 pub type StorageHub = Storage<hyper::Client, yup_oauth2::ServiceAccountAccess<hyper::Client>>;
@@ -238,7 +238,8 @@ impl GCloudClient {
         name: &str,
     ) -> Result<String, Error> {
         // Parse address to get bucket and object name
-        let (bucket_name, object_name): (String, String) = gs_uri_parsing::parse_bucket_and_object_name(address)?;
+        let (bucket_name, object_name): (String, String) =
+            gs_uri_parsing::parse_bucket_and_object_name(address)?;
         // Append name to the end of object name to get the full name we'll use
         let full_name: String = object_name + "/" + name;
         // Get the storage hub mutex lock (unwrapping because we want to panic if the mutex is poisoned)

--- a/src/util/gs_uri_parsing.rs
+++ b/src/util/gs_uri_parsing.rs
@@ -1,7 +1,7 @@
 //! Provides functions for parsing gs uris and related operations
 
-use std::fmt;
 use percent_encoding::{AsciiSet, CONTROLS};
+use std::fmt;
 
 /// Prefix indicating a URI is a GS URI
 pub static GS_URI_PREFIX: &'static str = "gs://";
@@ -30,7 +30,7 @@ pub const GCLOUD_ENCODING_SET: &AsciiSet = &CONTROLS
 
 #[derive(Debug)]
 pub enum Error {
-    Parse(String)
+    Parse(String),
 }
 
 impl fmt::Display for Error {
@@ -104,5 +104,4 @@ mod tests {
         let failure = get_object_cloud_console_url_from_gs_uri(test_result_uri);
         assert!(matches!(failure, Err(Error::Parse(_))));
     }
-
 }

--- a/src/util/run_csv.rs
+++ b/src/util/run_csv.rs
@@ -18,7 +18,7 @@ use zip::ZipWriter;
 pub enum Error {
     IO(std::io::Error),
     CSV(csv::Error),
-    Zip(zip::result::ZipError)
+    Zip(zip::result::ZipError),
 }
 
 impl std::error::Error for Error {}
@@ -80,7 +80,9 @@ enum CSVContentsType {
 ///
 /// Zipping functionality is partially adapted from
 /// https://github.com/zip-rs/zip/blob/5d0f198124946b7be4e5969719a7f29f363118cd/examples/write_dir.rs
-pub fn write_run_data_to_csvs_and_zip_in_temp_dir(runs: &Vec<RunWithResultsAndErrorsData>) -> Result<TempDir, Error> {
+pub fn write_run_data_to_csvs_and_zip_in_temp_dir(
+    runs: &Vec<RunWithResultsAndErrorsData>,
+) -> Result<TempDir, Error> {
     let csv_dir: TempDir = write_run_data_to_csvs_in_temp_dir(runs)?;
     // Create a file to write the data to
     let mut zip_file_path: PathBuf = PathBuf::from(csv_dir.path());
@@ -95,7 +97,7 @@ pub fn write_run_data_to_csvs_and_zip_in_temp_dir(runs: &Vec<RunWithResultsAndEr
         "eval_inputs.csv",
         "test_options.csv",
         "eval_options.csv",
-        "results.csv"
+        "results.csv",
     ] {
         // Tell the zip writer we're starting a new file
         zip_writer.start_file(csv_filename, FileOptions::default())?;
@@ -215,7 +217,10 @@ fn build_metadata_rows(runs: &Vec<RunWithResultsAndErrorsData>) -> Vec<Vec<Strin
 /// Builds and returns a vec of rows containing a header followed by one row for each run in `runs`
 /// with its run_id and values corresponding to `csv_contents_type` (e.g. if `csv_contents_type` is
 /// CSVContentsType::TestInputs, the row will contain the values in the run's test_input field)
-fn build_rows(runs: &Vec<RunWithResultsAndErrorsData>, csv_contents_type: CSVContentsType) -> Vec<Vec<String>> {
+fn build_rows(
+    runs: &Vec<RunWithResultsAndErrorsData>,
+    csv_contents_type: CSVContentsType,
+) -> Vec<Vec<String>> {
     // First, we'll build our header row
     let mut headers: HashSet<String> = HashSet::new();
     // We'll keep track of the processed maps for each run so we don't have to process them more
@@ -341,14 +346,14 @@ fn init_writer_from_dir_and_name(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::read_to_string;
     use super::*;
-    use chrono::{NaiveDateTime, Utc};
-    use serde_json::json;
-    use tempfile::TempDir;
-    use uuid::Uuid;
     use crate::custom_sql_types::RunStatusEnum;
     use crate::models::run::RunWithResultsAndErrorsData;
+    use chrono::{NaiveDateTime, Utc};
+    use serde_json::json;
+    use std::fs::read_to_string;
+    use tempfile::TempDir;
+    use uuid::Uuid;
 
     fn create_test_runs() -> Vec<RunWithResultsAndErrorsData> {
         vec![
@@ -379,7 +384,7 @@ mod tests {
                     "output_file": "gs://example/path/to/file.mp4",
                     "output_number": 7
                 })),
-                errors: None
+                errors: None,
             },
             RunWithResultsAndErrorsData {
                 run_id: Uuid::parse_str("4f27abe7-2cfa-42c3-acc2-ce5344b0e471").unwrap(),
@@ -408,7 +413,7 @@ mod tests {
                     "output_file": "gs://example/path/to/different/file.mp4",
                     "output_number": 5
                 })),
-                errors: None
+                errors: None,
             },
             RunWithResultsAndErrorsData {
                 run_id: Uuid::parse_str("4b2d5150-7d86-4a11-888c-b78dc030ba4f").unwrap(),
@@ -439,7 +444,7 @@ mod tests {
                     "output_number": 5,
                     "new_result": "yes"
                 })),
-                errors: None
+                errors: None,
             },
             RunWithResultsAndErrorsData {
                 run_id: Uuid::parse_str("cf4b5cb2-976e-4f9c-91ba-2b421d61199b").unwrap(),
@@ -464,7 +469,7 @@ mod tests {
                 results: None,
                 errors: Some(json!([
                     "Carrot failed to start the run because of a weird error"
-                ]))
+                ])),
             },
         ]
     }
@@ -477,31 +482,61 @@ mod tests {
         let csv_dir: TempDir = write_run_data_to_csvs_and_zip_in_temp_dir(&runs).unwrap();
 
         // Check that each file matches what we expect
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "metadata.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "metadata.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/metadata.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "test_inputs.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "test_inputs.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/test_inputs.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "eval_inputs.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "eval_inputs.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/eval_inputs.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "results.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "results.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/results.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "test_options.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "test_options.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/test_options.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "eval_options.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "eval_options.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/eval_options.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
     }
-    
+
     #[test]
     fn write_run_data_to_csvs_in_temp_dir_success() {
         // Get test runs to use
@@ -510,27 +545,57 @@ mod tests {
         let csv_dir: TempDir = write_run_data_to_csvs_in_temp_dir(&runs).unwrap();
 
         // Check that each file matches what we expect
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "metadata.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "metadata.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/metadata.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "test_inputs.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "test_inputs.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/test_inputs.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "eval_inputs.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "eval_inputs.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/eval_inputs.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "results.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "results.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/results.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "test_options.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "test_options.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/test_options.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
 
-        let test_file_contents = read_to_string(format!("{}/{}", csv_dir.path().to_string_lossy(), "eval_options.csv")).unwrap();
+        let test_file_contents = read_to_string(format!(
+            "{}/{}",
+            csv_dir.path().to_string_lossy(),
+            "eval_options.csv"
+        ))
+        .unwrap();
         let truth_file_contents = read_to_string("testdata/util/run_csv/eval_options.csv").unwrap();
         assert_eq!(test_file_contents, truth_file_contents);
     }

--- a/src/util/wdl_storage.rs
+++ b/src/util/wdl_storage.rs
@@ -4,13 +4,13 @@ use crate::config::{GCSWdlStorageConfig, LocalWdlStorageConfig, WdlStorageConfig
 use crate::models::wdl_hash::{WdlDataToHash, WdlHashData};
 use crate::storage::gcloud_storage;
 use crate::storage::gcloud_storage::GCloudClient;
+use crate::util::gs_uri_parsing;
 use diesel::PgConnection;
 use std::fmt;
 use std::fs;
 use std::io::prelude::*;
 use std::path::PathBuf;
 use uuid::Uuid;
-use crate::util::gs_uri_parsing;
 
 #[derive(Debug)]
 pub enum Error {


### PR DESCRIPTION
Added a query param called `csv` to the find_runs and run find_by_id rest mappings, that, if set to `true` will return the result data as a zip of CSVs instead of as raw json.  Also updated the corresponding commands in carrot_cli with a new option called `--zip_csv [file]` for specifying that you want to download the data as a CSV zip and write it to the specified file.  Also updated the report section in the user guide accordingly.