### PR TITLE
Did some minor refactoring for organizational purposes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ impl Config {
     /// 1. A value for `github` and None for `custom_image_build`,
     /// 2. A value for `custom_image_builds` and None for `gcloud`, or
     /// 3. A value for `reporting` and None for `gcloud`
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         logging: LoggingConfig,
         api: ApiConfig,
@@ -323,10 +324,7 @@ pub enum EmailConfig {
 
 impl EmailConfig {
     pub fn is_server(&self) -> bool {
-        match self {
-            EmailConfig::Server(_) => true,
-            _ => false,
-        }
+        matches!(self, EmailConfig::Server(_))
     }
     pub fn as_server(&self) -> Option<&EmailServerConfig> {
         match self {
@@ -335,10 +333,7 @@ impl EmailConfig {
         }
     }
     pub fn is_sendmail(&self) -> bool {
-        match self {
-            EmailConfig::Sendmail(_) => true,
-            _ => false,
-        }
+        matches!(self, EmailConfig::Sendmail(_))
     }
     pub fn as_sendmail(&self) -> Option<&EmailSendmailConfig> {
         match self {
@@ -437,15 +432,12 @@ pub enum WdlStorageConfig {
     Local(LocalWdlStorageConfig),
     /// Mode for storing wdls in a GCS bucket
     #[serde(rename = "gcs")]
-    GCS(GCSWdlStorageConfig),
+    Gcs(GCSWdlStorageConfig),
 }
 
 impl WdlStorageConfig {
     pub fn is_local(&self) -> bool {
-        match self {
-            WdlStorageConfig::Local(_) => true,
-            _ => false,
-        }
+        matches!(self, WdlStorageConfig::Local(_))
     }
     pub fn as_local(&self) -> Option<&LocalWdlStorageConfig> {
         match self {
@@ -454,14 +446,11 @@ impl WdlStorageConfig {
         }
     }
     pub fn is_gcs(&self) -> bool {
-        match self {
-            WdlStorageConfig::GCS(_) => true,
-            _ => false,
-        }
+        matches!(self, WdlStorageConfig::Gcs(_))
     }
     pub fn as_gcs(&self) -> Option<&GCSWdlStorageConfig> {
         match self {
-            WdlStorageConfig::GCS(s) => Some(s),
+            WdlStorageConfig::Gcs(s) => Some(s),
             _ => None,
         }
     }
@@ -469,7 +458,7 @@ impl WdlStorageConfig {
     /// gs uri
     pub fn wdl_location(&self) -> &String {
         match self {
-            WdlStorageConfig::GCS(gcs_config) => gcs_config.wdl_location(),
+            WdlStorageConfig::Gcs(gcs_config) => gcs_config.wdl_location(),
             WdlStorageConfig::Local(local_config) => local_config.wdl_location(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ mod requests;
 mod routes;
 mod run_error_logger;
 mod schema;
-mod storage;
 mod util;
 mod validation;
 
@@ -44,6 +43,7 @@ embed_migrations!("migrations");
 /// Creates a status manager and starts it running in its own thread.  Uses `db_pool` for database
 /// connections and `carrot_config` for configuring the status manager and related entities.
 /// Returns a sender for sending a terminate message, and a join handle for joining to the thread
+#[must_use]
 pub fn run_status_manager(
     db_pool: db::DbPool,
     carrot_config: config::Config,
@@ -72,6 +72,7 @@ pub fn run_status_manager(
 /// Creates a gcloud subscriber and starts it running in its own thread.  Uses `db_pool` for database
 /// connections and `carrot_config` for configuring the status manager and related entities.
 /// Returns a sender for sending a terminate message, and a join handle for joining to the thread
+#[must_use]
 pub fn run_gcloud_subscriber(
     db_pool: db::DbPool,
     carrot_config: config::Config,
@@ -87,7 +88,7 @@ pub fn run_gcloud_subscriber(
                 db_pool,
                 carrot_config,
                 subscriber_receive,
-            ))
+            ));
         })
         .expect("Failed to spawn gcloud subscriber thread");
 
@@ -116,10 +117,10 @@ fn main() {
     // Initialize logger with level from config
     let mut logger = simple_logger::SimpleLogger::new()
         .with_utc_timestamps()
-        .with_level(carrot_config.logging().level().to_owned().to_level_filter());
+        .with_level(carrot_config.logging().level().clone().to_level_filter());
     // Add any module-specific levels
     for item in carrot_config.logging().modules() {
-        logger = logger.with_module_level(item.0, item.1.to_owned().to_level_filter());
+        logger = logger.with_module_level(item.0, item.1.clone().to_level_filter());
     }
     logger.init().expect("Failed to initialize logger");
 

--- a/src/manager/github_runner.rs
+++ b/src/manager/github_runner.rs
@@ -154,22 +154,20 @@ impl GithubRunner {
         request: &GithubRunRequest,
     ) -> Result<RunData, Error> {
         // Build test and eval input jsons from the request, if it has values for the keys
-        let test_input = match &request.test_input_key {
-            Some(key) => Some(GithubRunner::build_input_from_key_and_software_and_commit(
+        let test_input = request.test_input_key.as_ref().map(|key| {
+            GithubRunner::build_input_from_key_and_software_and_commit(
                 key,
                 &request.software_name,
                 &request.commit,
-            )),
-            None => None,
-        };
-        let eval_input = match &request.eval_input_key {
-            Some(key) => Some(GithubRunner::build_input_from_key_and_software_and_commit(
+            )
+        });
+        let eval_input = request.eval_input_key.as_ref().map(|key| {
+            GithubRunner::build_input_from_key_and_software_and_commit(
                 key,
                 &request.software_name,
                 &request.commit,
-            )),
-            None => None,
-        };
+            )
+        });
         // Start run
         Ok(self
             .test_runner
@@ -264,8 +262,8 @@ mod tests {
         email_base_name: &str,
     ) -> TestData {
         let pipeline = insert_test_pipeline(conn);
-        let template = insert_test_template_with_pipeline_id(conn, pipeline.pipeline_id.clone());
-        let test = insert_test_test_with_template_id(conn, template.template_id.clone());
+        let template = insert_test_template_with_pipeline_id(conn, pipeline.pipeline_id);
+        let test = insert_test_test_with_template_id(conn, template.template_id);
 
         let new_subscription = NewSubscription {
             entity_type: EntityTypeEnum::Pipeline,

--- a/src/manager/util.rs
+++ b/src/manager/util.rs
@@ -20,14 +20,8 @@ pub async fn start_job_from_file(
     inputs_file_path: &Path,
     options_file_path: Option<&Path>,
 ) -> Result<WorkflowIdAndStatus, CromwellRequestError> {
-    let options_file_path = match options_file_path {
-        Some(file_path) => Some(PathBuf::from(file_path)),
-        None => None,
-    };
-    let wdl_deps_file_path: Option<PathBuf> = match wdl_deps_file_path {
-        Some(file_path) => Some(PathBuf::from(file_path)),
-        None => None,
-    };
+    let options_file_path = options_file_path.map(PathBuf::from);
+    let wdl_deps_file_path: Option<PathBuf> = wdl_deps_file_path.map(PathBuf::from);
     // Build request parameters
     let cromwell_params = cromwell_requests::StartJobParams {
         labels: None,
@@ -41,7 +35,7 @@ pub async fn start_job_from_file(
         workflow_options: options_file_path,
         workflow_root: None,
         workflow_source: Some(PathBuf::from(wdl_file_path)),
-        workflow_type: Some(WorkflowTypeEnum::WDL),
+        workflow_type: Some(WorkflowTypeEnum::Wdl),
         workflow_type_version: None,
         workflow_url: None,
     };

--- a/src/models/pipeline.rs
+++ b/src/models/pipeline.rs
@@ -108,7 +108,7 @@ impl PipelineData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &*sort_clause.key {
                     "pipeline_id" => {

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -5,7 +5,7 @@
 //! contained within the report is defined within the sections mapped to it. Represented in the
 //! database by the REPORT table.
 
-use crate::custom_sql_types::{ReportStatusEnum, REPORT_FAILURE_STATUSES};
+use crate::custom_sql_types::REPORT_FAILURE_STATUSES;
 use crate::schema::report;
 use crate::schema::report::dsl::*;
 use crate::schema::run_report;
@@ -158,7 +158,7 @@ impl ReportData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &*sort_clause.key {
                     "report_id" => {
@@ -293,12 +293,7 @@ impl ReportData {
         // Query the run_reports table for non failed run reports
         let non_failed_run_reports_count = run_report::dsl::run_report
             .filter(run_report::dsl::report_id.eq(id))
-            .filter(
-                run_report::dsl::status.ne(all(REPORT_FAILURE_STATUSES
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<ReportStatusEnum>>())),
-            )
+            .filter(run_report::dsl::status.ne(all(REPORT_FAILURE_STATUSES.to_vec())))
             .select(run_report::dsl::run_id)
             .first::<Uuid>(conn);
 
@@ -317,7 +312,7 @@ impl ReportData {
 mod tests {
 
     use super::*;
-    use crate::custom_sql_types::RunStatusEnum;
+    use crate::custom_sql_types::{ReportStatusEnum, RunStatusEnum};
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::run::{NewRun, RunData};
     use crate::models::run_report::{NewRunReport, RunReportData};

--- a/src/models/result.rs
+++ b/src/models/result.rs
@@ -117,7 +117,7 @@ impl ResultData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "result_id" => {

--- a/src/models/run.rs
+++ b/src/models/run.rs
@@ -242,7 +242,7 @@ impl RunData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {
@@ -437,7 +437,7 @@ impl RunData {
         };
         // Do the delete in a transaction
         #[cfg(not(test))]
-        return conn.build_transaction().run(|| delete_closure());
+        return conn.build_transaction().run(delete_closure);
 
         // Tests do all database stuff in transactions that are not committed so they don't interfere
         // with other tests. An unfortunate side effect of this is that we can't use transactions in
@@ -556,7 +556,7 @@ impl RunWithResultsAndErrorsData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {
@@ -788,7 +788,7 @@ mod tests {
 
         let new_run_result = NewRunResult {
             run_id: id.clone(),
-            result_id: new_result.result_id.clone(),
+            result_id: new_result.result_id,
             value: rand_result.to_string(),
         };
 
@@ -813,7 +813,7 @@ mod tests {
 
         let new_run_result2 = NewRunResult {
             run_id: id.clone(),
-            result_id: new_result2.result_id.clone(),
+            result_id: new_result2.result_id,
             value: String::from(rand_result),
         };
 
@@ -1130,7 +1130,7 @@ mod tests {
 
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
-            software_id: new_software.software_id.clone(),
+            software_id: new_software.software_id,
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version)
@@ -1138,7 +1138,7 @@ mod tests {
 
         let new_software_version2 = NewSoftwareVersion {
             commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
-            software_id: new_software.software_id.clone(),
+            software_id: new_software.software_id,
         };
 
         let new_software_version2 = SoftwareVersionData::create(conn, new_software_version2)
@@ -1146,7 +1146,7 @@ mod tests {
 
         let new_run_software_version = NewRunSoftwareVersion {
             run_id: id,
-            software_version_id: new_software_version.software_version_id.clone(),
+            software_version_id: new_software_version.software_version_id,
         };
 
         run_software_versions.push(
@@ -1156,7 +1156,7 @@ mod tests {
 
         let new_run_software_version = NewRunSoftwareVersion {
             run_id: id,
-            software_version_id: new_software_version2.software_version_id.clone(),
+            software_version_id: new_software_version2.software_version_id,
         };
 
         run_software_versions.push(
@@ -1567,7 +1567,7 @@ mod tests {
             test_options: None,
             eval_input: None,
             eval_options: None,
-            test_cromwell_job_id: Some(test_run.test_cromwell_job_id.clone().unwrap()),
+            test_cromwell_job_id: test_run.test_cromwell_job_id.clone(),
             eval_cromwell_job_id: None,
             created_before: None,
             created_after: None,
@@ -1604,7 +1604,7 @@ mod tests {
             eval_input: None,
             eval_options: None,
             test_cromwell_job_id: None,
-            eval_cromwell_job_id: Some(test_run.eval_cromwell_job_id.clone().unwrap()),
+            eval_cromwell_job_id: test_run.eval_cromwell_job_id.clone(),
             created_before: None,
             created_after: None,
             created_by: None,

--- a/src/models/run_error.rs
+++ b/src/models/run_error.rs
@@ -112,7 +112,7 @@ impl RunErrorData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_error_id" => {

--- a/src/models/run_is_from_github.rs
+++ b/src/models/run_is_from_github.rs
@@ -110,7 +110,7 @@ impl RunIsFromGithubData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {
@@ -282,9 +282,9 @@ mod tests {
         let new_runs = insert_test_runs(conn);
 
         let ids = vec![
-            new_runs.get(0).unwrap().run_id.clone(),
-            new_runs.get(1).unwrap().run_id.clone(),
-            new_runs.get(2).unwrap().run_id.clone(),
+            new_runs.get(0).unwrap().run_id,
+            new_runs.get(1).unwrap().run_id,
+            new_runs.get(2).unwrap().run_id,
         ];
 
         let new_run_is_from_githubs = insert_test_run_is_from_githubs_with_run_ids(conn, ids);

--- a/src/models/run_report.rs
+++ b/src/models/run_report.rs
@@ -145,7 +145,7 @@ impl RunReportData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {

--- a/src/models/run_result.rs
+++ b/src/models/run_result.rs
@@ -127,7 +127,7 @@ impl RunResultData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {
@@ -798,8 +798,8 @@ mod tests {
 
         let test_run_result2 = RunResultData::find_by_run_and_result(
             &conn,
-            test_run_result.run_id.clone(),
-            test_run_result.result_id.clone(),
+            test_run_result.run_id,
+            test_run_result.result_id,
         );
 
         assert!(matches!(

--- a/src/models/run_software_version.rs
+++ b/src/models/run_software_version.rs
@@ -98,7 +98,7 @@ impl RunSoftwareVersionData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "run_id" => {
@@ -258,8 +258,8 @@ mod tests {
             .expect("Failed inserting test software_version");
 
         let new_run_software_version = NewRunSoftwareVersion {
-            run_id: new_run.run_id.clone(),
-            software_version_id: new_software_version.software_version_id.clone(),
+            run_id: new_run.run_id,
+            software_version_id: new_software_version.software_version_id,
         };
 
         RunSoftwareVersionData::create(conn, new_run_software_version)
@@ -316,7 +316,7 @@ mod tests {
 
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
-            software_id: new_software.software_id.clone(),
+            software_id: new_software.software_id,
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version)
@@ -324,15 +324,15 @@ mod tests {
 
         let new_software_version2 = NewSoftwareVersion {
             commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
-            software_id: new_software.software_id.clone(),
+            software_id: new_software.software_id,
         };
 
         let new_software_version2 = SoftwareVersionData::create(conn, new_software_version2)
             .expect("Failed inserting test software_version");
 
         let new_run_software_version = NewRunSoftwareVersion {
-            run_id: new_run.run_id.clone(),
-            software_version_id: new_software_version.software_version_id.clone(),
+            run_id: new_run.run_id,
+            software_version_id: new_software_version.software_version_id,
         };
 
         run_software_versions.push(
@@ -341,8 +341,8 @@ mod tests {
         );
 
         let new_run_software_version = NewRunSoftwareVersion {
-            run_id: new_run2.run_id.clone(),
-            software_version_id: new_software_version.software_version_id.clone(),
+            run_id: new_run2.run_id,
+            software_version_id: new_software_version.software_version_id,
         };
 
         run_software_versions.push(
@@ -351,8 +351,8 @@ mod tests {
         );
 
         let new_run_software_version = NewRunSoftwareVersion {
-            run_id: new_run2.run_id.clone(),
-            software_version_id: new_software_version2.software_version_id.clone(),
+            run_id: new_run2.run_id,
+            software_version_id: new_software_version2.software_version_id,
         };
 
         run_software_versions.push(
@@ -557,8 +557,8 @@ mod tests {
 
         let test_run_software_version2 = RunSoftwareVersionData::find_by_run_and_software_version(
             &conn,
-            test_run_software_version.run_id.clone(),
-            test_run_software_version.software_version_id.clone(),
+            test_run_software_version.run_id,
+            test_run_software_version.software_version_id,
         )
         .unwrap();
 
@@ -602,8 +602,8 @@ mod tests {
 
         let test_run_software_version2 = RunSoftwareVersionData::find_by_run_and_software_version(
             &conn,
-            test_run_software_version.run_id.clone(),
-            test_run_software_version.software_version_id.clone(),
+            test_run_software_version.run_id,
+            test_run_software_version.software_version_id,
         );
 
         assert!(matches!(

--- a/src/models/software.rs
+++ b/src/models/software.rs
@@ -140,7 +140,7 @@ impl SoftwareData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &*sort_clause.key {
                     "software_id" => {

--- a/src/models/software_build.rs
+++ b/src/models/software_build.rs
@@ -174,7 +174,7 @@ impl SoftwareBuildData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "software_build_id" => {
@@ -357,7 +357,7 @@ mod tests {
         let mut software_versions = Vec::new();
 
         let new_software_version = NewSoftwareVersion {
-            software_id: new_software.software_id.clone(),
+            software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
         };
 
@@ -488,7 +488,7 @@ mod tests {
         let new_run = RunData::create(&conn, new_run).expect("Failed to insert run");
 
         let new_run_software_version = NewRunSoftwareVersion {
-            run_id: new_run.run_id.clone(),
+            run_id: new_run.run_id,
             software_version_id: id,
         };
 

--- a/src/models/software_version.rs
+++ b/src/models/software_version.rs
@@ -139,7 +139,7 @@ impl SoftwareVersionData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "software_version_id" => {
@@ -237,8 +237,8 @@ mod tests {
         let new_softwares = insert_test_softwares(conn);
 
         let ids = vec![
-            new_softwares.get(0).unwrap().software_id.clone(),
-            new_softwares.get(1).unwrap().software_id.clone(),
+            new_softwares.get(0).unwrap().software_id,
+            new_softwares.get(1).unwrap().software_id,
         ];
 
         let new_software_versions = insert_test_software_versions_with_software_id(conn, ids);

--- a/src/models/sql_functions.rs
+++ b/src/models/sql_functions.rs
@@ -5,6 +5,6 @@
 //! them here, along with any custom functions we ever define, so they can be used in queries in
 //! the models submodules
 
-use diesel::sql_types::*;
+use diesel::sql_types::Text;
 
 sql_function!(fn lower(x: Text) -> Text);

--- a/src/models/subscription.rs
+++ b/src/models/subscription.rs
@@ -154,7 +154,7 @@ impl SubscriptionData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &*sort_clause.key {
                     "subscription_id" => {
@@ -322,8 +322,8 @@ mod tests {
 
     fn insert_test_subscriptions_with_entities(conn: &PgConnection) -> Vec<SubscriptionData> {
         let pipeline = insert_test_pipeline(conn);
-        let template = insert_test_template_with_pipeline_id(conn, pipeline.pipeline_id.clone());
-        let test = insert_test_test_with_template_id(conn, template.template_id.clone());
+        let template = insert_test_template_with_pipeline_id(conn, pipeline.pipeline_id);
+        let test = insert_test_test_with_template_id(conn, template.template_id);
 
         let mut subscriptions = Vec::new();
 
@@ -524,7 +524,7 @@ mod tests {
         let test_query = SubscriptionQuery {
             subscription_id: None,
             entity_type: None,
-            entity_id: Some(test_subscriptions[0].entity_id.clone()),
+            entity_id: Some(test_subscriptions[0].entity_id),
             created_before: None,
             created_after: None,
             email: None,
@@ -642,12 +642,12 @@ mod tests {
         let test_subscription = insert_test_subscription(&conn);
 
         // Make sure we can find it
-        SubscriptionData::find_by_id(&conn, test_subscription.subscription_id.clone())
+        SubscriptionData::find_by_id(&conn, test_subscription.subscription_id)
             .expect("Could not find test_subscription after insert");
 
         // Delete it
         let delete_params = SubscriptionDeleteParams {
-            subscription_id: Some(test_subscription.subscription_id.clone()),
+            subscription_id: Some(test_subscription.subscription_id),
             entity_type: None,
             entity_id: None,
             created_before: None,

--- a/src/models/template_result.rs
+++ b/src/models/template_result.rs
@@ -181,7 +181,7 @@ impl TemplateResultData {
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
-            let sort = util::sort_string::parse_sort_string(&sort);
+            let sort = util::sort_string::parse(&sort);
             for sort_clause in sort {
                 match &sort_clause.key[..] {
                     "template_id" => {

--- a/src/requests/cromwell_requests.rs
+++ b/src/requests/cromwell_requests.rs
@@ -54,16 +54,16 @@ pub struct StartJobParams {
 #[derive(Serialize)]
 #[allow(dead_code)] // Because we're not using all variations currently
 pub enum WorkflowTypeEnum {
-    WDL,
-    CWL,
+    Wdl,
+    Cwl,
 }
 
 /// Mapping workflow types to the values the Cromwell API expects
 impl fmt::Display for WorkflowTypeEnum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            WorkflowTypeEnum::WDL => write!(f, "{}", "WDL"),
-            WorkflowTypeEnum::CWL => write!(f, "{}", "CWL"),
+            WorkflowTypeEnum::Wdl => write!(f, "WDL"),
+            WorkflowTypeEnum::Cwl => write!(f, "CWL"),
         }
     }
 }
@@ -83,9 +83,9 @@ pub enum WorkflowTypeVersionEnum {
 impl fmt::Display for WorkflowTypeVersionEnum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            WorkflowTypeVersionEnum::DraftDash2 => write!(f, "{}", "draft-2"),
-            WorkflowTypeVersionEnum::OnePointZero => write!(f, "{}", "1.0"),
-            WorkflowTypeVersionEnum::VOnePointZero => write!(f, "{}", "v1.0"),
+            WorkflowTypeVersionEnum::DraftDash2 => write!(f, "draft-2"),
+            WorkflowTypeVersionEnum::OnePointZero => write!(f, "1.0"),
+            WorkflowTypeVersionEnum::VOnePointZero => write!(f, "v1.0"),
         }
     }
 }
@@ -321,7 +321,7 @@ impl CromwellClient {
         // Parse response body into Json
         match serde_json::from_str(body_utf8) {
             Ok(value) => Ok(value),
-            Err(e) => return Err(e.into()),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/src/requests/github_requests.rs
+++ b/src/requests/github_requests.rs
@@ -7,7 +7,7 @@ use mockito;
 use serde_json::json;
 use std::{error, fmt};
 
-static GITHUB_BASE_ADDRESS: &'static str = "https://api.github.com";
+static GITHUB_BASE_ADDRESS: &str = "https://api.github.com";
 
 /// Struct for interacting with the GitHub api
 pub struct GithubClient {

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -2,5 +2,6 @@
 
 // Declared as public to be accessed elsewhere
 pub mod cromwell_requests;
+pub mod gcloud_storage;
 pub mod github_requests;
 pub mod test_resource_requests;

--- a/src/routes/multipart_handling.rs
+++ b/src/routes/multipart_handling.rs
@@ -121,10 +121,10 @@ impl From<std::io::Error> for Error {
 /// 4. A field is encountered that is not present in either of the expected field lists
 pub async fn extract_data_from_multipart(
     mut payload: Multipart,
-    expected_text_fields: &Vec<&str>,
-    expected_file_fields: &Vec<&str>,
-    required_text_fields: &Vec<&str>,
-    required_file_fields: &Vec<&str>,
+    expected_text_fields: &[&str],
+    expected_file_fields: &[&str],
+    required_text_fields: &[&str],
+    required_file_fields: &[&str],
 ) -> Result<(HashMap<String, String>, HashMap<String, NamedTempFile>), Error> {
     // Build maps of the fields we process to return
     let mut string_map: HashMap<String, String> = HashMap::new();
@@ -236,8 +236,8 @@ pub fn multipart_content_type_guard(req: &RequestHead) -> bool {
 /// Returns () if `string_map` contains all the keys in `required_text_fields` and `file_map`
 /// contains all the keys in `required_file_fields`.  Otherwise, returns an error
 fn check_for_required_fields(
-    required_text_fields: &Vec<&str>,
-    required_file_fields: &Vec<&str>,
+    required_text_fields: &[&str],
+    required_file_fields: &[&str],
     string_map: &HashMap<String, String>,
     file_map: &HashMap<String, NamedTempFile>,
 ) -> Result<(), Error> {

--- a/src/routes/util.rs
+++ b/src/routes/util.rs
@@ -12,15 +12,15 @@ use uuid::Uuid;
 /// parsing Uuid path variables and having that take up a bunch of space
 pub fn parse_id(id: &str) -> Result<Uuid, HttpResponse> {
     match Uuid::parse_str(id) {
-        Ok(id) => return Ok(id),
+        Ok(id) => Ok(id),
         Err(e) => {
             error!("{}", e);
             // If it doesn't parse successfully, return an error to the user
-            return Err(HttpResponse::BadRequest().json(ErrorBody {
+            Err(HttpResponse::BadRequest().json(ErrorBody {
                 title: "ID formatted incorrectly".to_string(),
                 status: 400,
                 detail: "ID must be formatted as a Uuid".to_string(),
-            }));
+            }))
         }
     }
 }

--- a/src/run_error_logger.rs
+++ b/src/run_error_logger.rs
@@ -5,15 +5,15 @@ use uuid::Uuid;
 
 /// Writes `message` to the log as an error and inserts a run error into the db for the run with id
 /// `run_id`.  Logs any errors encountered trying to do the insert
-pub fn log_error(conn: &PgConnection, run_id: Uuid, message: String) {
+pub fn log_error(conn: &PgConnection, run_id: Uuid, message: &str) {
     // Log the message first
-    error!("{}", &message);
+    error!("{}", message);
     // Now write it to the db
     if let Err(e) = RunErrorData::create(
         conn,
         NewRunError {
             run_id,
-            error: message.clone(),
+            error: String::from(message),
         },
     ) {
         error!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,2 +1,0 @@
-//! Contains modules for storing and retrieving files from different places
-pub mod gcloud_storage;

--- a/src/util/gs_uri_parsing.rs
+++ b/src/util/gs_uri_parsing.rs
@@ -4,7 +4,7 @@ use percent_encoding::{AsciiSet, CONTROLS};
 use std::fmt;
 
 /// Prefix indicating a URI is a GS URI
-pub static GS_URI_PREFIX: &'static str = "gs://";
+pub static GS_URI_PREFIX: &str = "gs://";
 
 /// A set of all the characters that need to be percent-encoded for the GCS API
 pub const GCLOUD_ENCODING_SET: &AsciiSet = &CONTROLS
@@ -45,7 +45,7 @@ impl fmt::Display for Error {
 /// `object_uri` in the format gs://bucketname/ob/ject/nam/e
 pub fn parse_bucket_and_object_name(object_uri: &str) -> Result<(String, String), Error> {
     // Split it so we can extract the parts we want
-    let split_result_uri: Vec<&str> = object_uri.split("/").collect();
+    let split_result_uri: Vec<&str> = object_uri.split('/').collect();
     // If the split uri isn't at least 4 parts, this isn't a valid uri
     if split_result_uri.len() < 4 {
         return Err(Error::Parse(format!(
@@ -56,7 +56,7 @@ pub fn parse_bucket_and_object_name(object_uri: &str) -> Result<(String, String)
     // Bucket name comes after the gs://
     let bucket_name = String::from(split_result_uri[2]);
     // Object name is everything after the bucket name
-    let object_name = String::from(object_uri.splitn(4, "/").collect::<Vec<&str>>()[3]);
+    let object_name = String::from(object_uri.splitn(4, '/').collect::<Vec<&str>>()[3]);
     Ok((bucket_name, object_name))
 }
 

--- a/src/util/sort_string.rs
+++ b/src/util/sort_string.rs
@@ -11,17 +11,17 @@ pub struct SortClause {
 ///
 /// Expects sort strings to be comma-separated lists of sort keys, optionally enclosed in asc() or
 /// desc().  For example, asc(name),desc(created_at),pipeline_id
-pub fn parse_sort_string(sort_string: &str) -> Vec<SortClause> {
+pub fn parse(sort_string: &str) -> Vec<SortClause> {
     let mut sort_clauses = Vec::new();
 
-    for clause in sort_string.split(",") {
+    for clause in sort_string.split(',') {
         let clause = clause.trim();
         if clause.starts_with("asc(") {
             sort_clauses.push(SortClause {
                 key: String::from(
                     clause
                         .trim_start_matches("asc(")
-                        .trim_end_matches(")")
+                        .trim_end_matches(')')
                         .trim(),
                 ),
                 ascending: true,
@@ -31,7 +31,7 @@ pub fn parse_sort_string(sort_string: &str) -> Vec<SortClause> {
                 key: String::from(
                     clause
                         .trim_start_matches("desc(")
-                        .trim_end_matches(")")
+                        .trim_end_matches(')')
                         .trim(),
                 ),
                 ascending: false,
@@ -52,21 +52,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_sort_string_empty() {
-        assert_eq!(parse_sort_string(""), Vec::new());
+    fn parse_empty() {
+        assert_eq!(parse(""), Vec::new());
     }
 
     #[test]
-    fn parse_sort_string_whitespace() {
+    fn parse_whitespace() {
         assert_eq!(
-            parse_sort_string("  \n\r\t\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}"),
+            parse("  \n\r\t\u{000B}\u{000C}\u{0085}\u{2028}\u{2029}"),
             Vec::new()
         );
     }
 
     #[test]
-    fn parse_sort_string_middle_whitespace() {
-        let sort = parse_sort_string("asc(name), ,version");
+    fn parse_middle_whitespace() {
+        let sort = parse("asc(name), ,version");
         assert_eq!(
             sort[0],
             SortClause {
@@ -84,8 +84,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_sort_string_starting_whitespace() {
-        let sort = parse_sort_string(" ,desc(description),version");
+    fn parse_starting_whitespace() {
+        let sort = parse(" ,desc(description),version");
         assert_eq!(
             sort[0],
             SortClause {
@@ -103,8 +103,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_sort_string_ending_whitespace() {
-        let sort = parse_sort_string("asc(name),desc(description), ");
+    fn parse_ending_whitespace() {
+        let sort = parse("asc(name),desc(description), ");
         assert_eq!(
             sort[0],
             SortClause {
@@ -122,8 +122,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_sort_string_normal() {
-        let sort = parse_sort_string("asc(name),desc(description),version");
+    fn parse_normal() {
+        let sort = parse("asc(name),desc(description),version");
         assert_eq!(
             sort[0],
             SortClause {

--- a/src/validation/womtool.rs
+++ b/src/validation/womtool.rs
@@ -13,7 +13,7 @@ pub enum Error {
     IO(std::io::Error),
     Invalid(String),
     FromUtf8(std::string::FromUtf8Error),
-    JSON(serde_json::error::Error),
+    Json(serde_json::error::Error),
 }
 
 impl fmt::Display for Error {
@@ -22,7 +22,7 @@ impl fmt::Display for Error {
             Error::IO(e) => write!(f, "Womtool IO Error {}", e),
             Error::Invalid(msg) => write!(f, "Womtool Invalid Error {}", msg),
             Error::FromUtf8(e) => write!(f, "Womtool FromUtf8Error Error {}", e),
-            Error::JSON(e) => write!(f, "Womtool JSON Error {}", e),
+            Error::Json(e) => write!(f, "Womtool JSON Error {}", e),
         }
     }
 }
@@ -42,7 +42,7 @@ impl From<std::string::FromUtf8Error> for Error {
 }
 impl From<serde_json::error::Error> for Error {
     fn from(e: serde_json::error::Error) -> Error {
-        Error::JSON(e)
+        Error::Json(e)
     }
 }
 


### PR DESCRIPTION
* Routes
  * Changed return type of all routes functions to HttpResponse
    * Adds a little verbosity to error handling in some places but more accurately reflects that each of these functions generates a response to return
    * This also necessitated the replacement of the `web::block(...).await.map(...).map_err(...)` stuff with `match web::block(...).await{Ok(...)=>{...},Err(...)=>{...}` which is fine with me because I think that's easier to read anyway
  * Switched parsing id params to using the `util::parse_id` function
    * Cleans up a bunch of redundant code
* Storage
  * Moved gcloud_storage to the requests module because it really should just go there
  * Removed the storage module because it no longer serves a purpose
* General
  * Ran the rust-fmt formatter to fix formatting issues
  * Used rust clippy to make a bunch of other suggested format changes