### PR TITLE
Added the option to specify a machine_type in software for gcloud build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.55.0 as builder
+FROM rust:1.57.0 as builder
 WORKDIR /usr/src/carrot
 COPY . .
 RUN cargo install --path .

--- a/carrot_cli/src/carrot_cli/rest/software.py
+++ b/carrot_cli/src/carrot_cli/rest/software.py
@@ -15,6 +15,7 @@ def find(
     name="",
     description="",
     repository_url="",
+    machine_type="",
     created_by="",
     created_before="",
     created_after="",
@@ -29,6 +30,7 @@ def find(
         ("name", name),
         ("description", description),
         ("repository_url", repository_url),
+        ("machine_type", machine_type),
         ("created_by", created_by),
         ("created_before", created_before),
         ("created_after", created_after),
@@ -39,23 +41,25 @@ def find(
     return request_handler.find("software", params)
 
 
-def create(name, description, repository_url, created_by):
+def create(name, description, repository_url, machine_type, created_by):
     """Submits a request to CARROT's software create mapping"""
     # Create parameter list
     params = [
         ("name", name),
         ("description", description),
         ("repository_url", repository_url),
+        ("machine_type", machine_type),
         ("created_by", created_by),
     ]
     return request_handler.create("software", params)
 
 
-def update(software_id, name, description):
+def update(software_id, name, description, machine_type):
     """Submits a request to CARROT's software update mapping"""
     # Create parameter list
     params = [
         ("name", name),
         ("description", description),
+        ("machine_type", machine_type),
     ]
     return request_handler.update("software", software_id, params)

--- a/carrot_cli/src/carrot_cli/software/command.py
+++ b/carrot_cli/src/carrot_cli/software/command.py
@@ -38,7 +38,7 @@ def find_by_id(id):
     "--machine_type",
     default="",
     help="Optional machine type for Google Cloud Build to use for building this software.",
-    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", "e2-highcpu-8", "e2-highcpu-32", ''], case_sensitive=False)
 )
 @click.option(
     "--created_before",
@@ -119,7 +119,7 @@ def find(
     "--machine_type",
     default="",
     help="Optional machine type for Google Cloud Build to use for building this software.",
-    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", "e2-highcpu-8", "e2-highcpu-32", ''], case_sensitive=False)
 )
 @click.option(
     "--created_by",
@@ -150,7 +150,7 @@ def create(name, description, repository_url, machine_type, created_by):
     "--machine_type",
     default="",
     help="Optional machine type for Google Cloud Build to use for building this software.",
-    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", "e2-highcpu-8", "e2-highcpu-32", ''], case_sensitive=False)
 )
 def update(software, name, description, machine_type):
     """Update software definition for SOFTWARE (id or name) with the specified parameters"""

--- a/carrot_cli/src/carrot_cli/software/command.py
+++ b/carrot_cli/src/carrot_cli/software/command.py
@@ -35,6 +35,12 @@ def find_by_id(id):
     help="The url of the repository where the software code is hosted",
 )
 @click.option(
+    "--machine_type",
+    default="",
+    help="Optional machine type for Google Cloud Build to use for building this software.",
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+)
+@click.option(
     "--created_before",
     default="",
     help="Upper bound for software's created_at value, in the format YYYY-MM-DDThh:mm:ss.ssssss",
@@ -74,6 +80,7 @@ def find(
     name,
     description,
     repository_url,
+    machine_type,
     created_by,
     created_before,
     created_after,
@@ -88,6 +95,7 @@ def find(
             name,
             description,
             repository_url,
+            machine_type,
             created_by,
             created_before,
             created_after,
@@ -108,11 +116,17 @@ def find(
     required=True,
 )
 @click.option(
+    "--machine_type",
+    default="",
+    help="Optional machine type for Google Cloud Build to use for building this software.",
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+)
+@click.option(
     "--created_by",
     default="",
     help="Email of the creator of the software.  Defaults to email config variable",
 )
-def create(name, description, repository_url, created_by):
+def create(name, description, repository_url, machine_type, created_by):
     """Create software definition with the specified parameters"""
     # If created_by is not set and there is an email config variable, fill with that
     if created_by == "":
@@ -125,18 +139,24 @@ def create(name, description, repository_url, created_by):
                 "there must be a value set for email."
             )
             sys.exit(1)
-    print(software_rest.create(name, description, repository_url, created_by))
+    print(software_rest.create(name, description, repository_url, machine_type, created_by))
 
 
 @main.command(name="update")
 @click.argument("software")
 @click.option("--name", default="", help="The name of the software")
 @click.option("--description", default="", help="The description of the software")
-def update(software, name, description):
+@click.option(
+    "--machine_type",
+    default="",
+    help="Optional machine type for Google Cloud Build to use for building this software.",
+    type=click.Choice(["standard", "n1-highcpu-8", "n1-highcpu-32", ''], case_sensitive=False)
+)
+def update(software, name, description, machine_type):
     """Update software definition for SOFTWARE (id or name) with the specified parameters"""
     # Process software to get id if it's a name
     id = dependency_util.get_id_from_id_or_name_and_handle_error(software, software_rest, "software_id", "software")
-    print(software_rest.update(id, name, description))
+    print(software_rest.update(id, name, description, machine_type))
 
 
 main.add_command(software_version.main)

--- a/carrot_cli/tests/unit/rest/test_software.py
+++ b/carrot_cli/tests/unit/rest/test_software.py
@@ -20,6 +20,7 @@ def unstub():
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/swordofprotection",
+                    "machine_type": "standard",
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -65,6 +66,7 @@ def test_find_by_id(find_by_id_data):
                 ("name", "Queen of Bright Moon software"),
                 ("description", ""),
                 ("repository_url", ""),
+                ("machine_type", ""),
                 ("created_by", ""),
                 ("created_before", ""),
                 ("created_after", ""),
@@ -77,6 +79,7 @@ def test_find_by_id(find_by_id_data):
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
                         "created_by": "glimmer@example.com",
+                        "machine_type": "standard",
                         "repository_url": "example.com/queenofbrightmoon",
                         "description": "This software leads the Rebellion",
                         "name": "Queen of Bright Moon software",
@@ -93,6 +96,7 @@ def test_find_by_id(find_by_id_data):
                 ("name", ""),
                 ("description", ""),
                 ("repository_url", ""),
+                ("machine_type", ""),
                 ("created_by", ""),
                 ("created_before", ""),
                 ("created_after", ""),
@@ -134,6 +138,7 @@ def test_find(find_data):
         find_data["params"][7][1],
         find_data["params"][8][1],
         find_data["params"][9][1],
+        find_data["params"][10][1],
     )
     assert result == find_data["return"]
 
@@ -145,6 +150,7 @@ def test_find(find_data):
                 ("name", "Horde Emperor software"),
                 ("description", "This software rules the known universe"),
                 ("repository_url", "example.com/hordeemperor"),
+                ("machine_type", "n1-highcpu-8"),
                 ("created_by", "hordeprime@example.com"),
             ],
             "return": json.dumps(
@@ -152,6 +158,7 @@ def test_find(find_data):
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
                     "repository_url": "example.com/hordeemperor",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This software rules the known universe",
                     "name": "Horde Emperor software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
@@ -165,6 +172,7 @@ def test_find(find_data):
                 ("name", "Horde Emperor software"),
                 ("description", "This software rules the known universe"),
                 ("repository_url", "example.com/hordeemperor"),
+                ("machine_type", "n1-highcpu-8"),
                 ("created_by", "hordeprime@example.com"),
             ],
             "return": json.dumps(
@@ -195,6 +203,7 @@ def test_create(create_data):
         create_data["params"][1][1],
         create_data["params"][2][1],
         create_data["params"][3][1],
+        create_data["params"][4][1],
     )
     assert result == create_data["return"]
 
@@ -209,12 +218,14 @@ def test_create(create_data):
                     "description",
                     "This software is trying to learn to process anger better",
                 ),
+                ("machine_type", "n1-highcpu-8"),
             ],
             "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
                     "repository_url": "example.com/catra",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This software is trying to learn to process anger better",
                     "name": "Catra software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
@@ -225,7 +236,7 @@ def test_create(create_data):
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
-            "params": [("name", "Angella software"), ("description", "")],
+            "params": [("name", "Angella software"), ("description", ""), ("machine_type", "")],
             "return": json.dumps(
                 {
                     "title": "Server error",
@@ -253,5 +264,6 @@ def test_update(update_data):
         update_data["id"],
         update_data["params"][0][1],
         update_data["params"][1][1],
+        update_data["params"][2][1],
     )
     assert result == update_data["return"]

--- a/carrot_cli/tests/unit/software/test_software_command.py
+++ b/carrot_cli/tests/unit/software/test_software_command.py
@@ -29,6 +29,7 @@ def no_email():
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/repo.git",
+                    "machine_type": "standard",
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -81,6 +82,8 @@ def test_find_by_id(find_by_id_data):
                 "This software will save Etheria",
                 "--repository_url",
                 "example.com/repo.git",
+                "--machine_type",
+                "n1-highcpu-8",
                 "--created_by",
                 "adora@example.com",
                 "--created_before",
@@ -99,6 +102,7 @@ def test_find_by_id(find_by_id_data):
                 "Sword of Protection software",
                 "This software will save Etheria",
                 "example.com/repo.git",
+                "n1-highcpu-8",
                 "adora@example.com",
                 "2020-10-00T00:00:00.000000",
                 "2020-09-00T00:00:00.000000",
@@ -111,6 +115,7 @@ def test_find_by_id(find_by_id_data):
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/repo.git",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -128,6 +133,7 @@ def test_find_by_id(find_by_id_data):
             ],
             "params": [
                 "986325ba-06fe-4b1a-9e96-47d4f36bf819",
+                "",
                 "",
                 "",
                 "",
@@ -165,6 +171,7 @@ def find_data(request):
         request.param["params"][7],
         request.param["params"][8],
         request.param["params"][9],
+        request.param["params"][10],
     ).thenReturn(request.param["return"])
     return request.param
 
@@ -187,6 +194,8 @@ def test_find(find_data):
                 "This software will save Etheria",
                 "--repository_url",
                 "example.com/repo.git",
+                "--machine_type",
+                "n1-highcpu-8",
                 "--created_by",
                 "adora@example.com",
             ],
@@ -194,6 +203,7 @@ def test_find(find_data):
                 "Sword of Protection software",
                 "This software will save Etheria",
                 "example.com/repo.git",
+                "n1-highcpu-8",
                 "adora@example.com",
             ],
             "return": json.dumps(
@@ -201,6 +211,7 @@ def test_find(find_data):
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/repo.git",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -219,6 +230,8 @@ def test_find(find_data):
                 "This software will save Etheria",
                 "--repository_url",
                 "example.com/repo.git",
+                "--machine_type",
+                "n1-highcpu-8",
             ],
             "params": [],
             "logging": "No email config variable set.  If a value is not specified for --created by, "
@@ -244,6 +257,7 @@ def create_data(request):
             request.param["params"][1],
             request.param["params"][2],
             request.param["params"][3],
+            request.param["params"][4],
         ).thenReturn(request.param["return"])
     return request.param
 
@@ -266,6 +280,8 @@ def test_create(create_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "--description",
                 "This new software replaced the broken one",
+                "--machine_type",
+                "n1-highcpu-8",
                 "--name",
                 "New Sword of Protection software",
             ],
@@ -273,12 +289,14 @@ def test_create(create_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "New Sword of Protection software",
                 "This new software replaced the broken one",
+                "n1-highcpu-8",
             ],
             "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/repo.git",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This new software replaced the broken one",
                     "name": "New Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -294,6 +312,8 @@ def test_create(create_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "--description",
                 "This new software replaced the broken one",
+                "--machine_type",
+                "n1-highcpu-8",
                 "--name",
                 "New Sword of Protection software",
             ],
@@ -301,6 +321,7 @@ def test_create(create_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "New Sword of Protection software",
                 "This new software replaced the broken one",
+                "n1-highcpu-8",
             ],
             "from_name": {
                 "name": "New Sword of Protection software",
@@ -310,6 +331,7 @@ def test_create(create_data, caplog):
                             "created_at": "2020-09-16T18:48:06.371563",
                             "created_by": "adora@example.com",
                             "repository_url": "example.com/repo.git",
+                            "machine_type": "standard",
                             "description": "This new software replaced the broken one",
                             "name": "New Sword of Protection software",
                             "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -324,6 +346,7 @@ def test_create(create_data, caplog):
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "repository_url": "example.com/repo.git",
+                    "machine_type": "n1-highcpu-8",
                     "description": "This new software replaced the broken one",
                     "name": "New Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -358,6 +381,7 @@ def update_data(request):
             request.param["params"][0],
             request.param["params"][1],
             request.param["params"][2],
+            request.param["params"][3],
         ).thenReturn(request.param["return"])
     return request.param
 

--- a/migrations/2022-06-15-145542_software_machine_type/down.sql
+++ b/migrations/2022-06-15-145542_software_machine_type/down.sql
@@ -1,0 +1,4 @@
+alter table software
+    drop column if exists machine_type;
+
+drop type if exists machine_type_enum;

--- a/migrations/2022-06-15-145542_software_machine_type/up.sql
+++ b/migrations/2022-06-15-145542_software_machine_type/up.sql
@@ -1,4 +1,4 @@
-create type machine_type_enum as enum('n1-highcpu-8', 'n1-highcpu-32', 'standard');
+create type machine_type_enum as enum('n1-highcpu-8', 'n1-highcpu-32', 'e2-highcpu-8', 'e2-highcpu-32', 'standard');
 
 alter table software
     add column machine_type machine_type_enum not null default 'standard';

--- a/migrations/2022-06-15-145542_software_machine_type/up.sql
+++ b/migrations/2022-06-15-145542_software_machine_type/up.sql
@@ -1,0 +1,4 @@
+create type machine_type_enum as enum('n1-highcpu-8', 'n1-highcpu-32', 'standard');
+
+alter table software
+    add column machine_type machine_type_enum not null default 'standard';

--- a/scripts/wdl/docker_build.wdl
+++ b/scripts/wdl/docker_build.wdl
@@ -33,7 +33,7 @@ task build_and_push {
     }
 
     runtime {
-        docker: "google/cloud-sdk:307.0.0"
+        docker: "google/cloud-sdk:392.0.0"
     }
 
 }

--- a/scripts/wdl/docker_build.wdl
+++ b/scripts/wdl/docker_build.wdl
@@ -7,6 +7,7 @@ task build_and_push {
         String software_name
         String commit_hash
         String registry_host
+        String machine_type
     }
 
     parameter_meta {
@@ -14,6 +15,7 @@ task build_and_push {
         software_name: "The name that will be used to name the docker image"
         commit_hash: "The hash for the commit to build from; will also be used to tag the image"
         registry_host: "The docker repository to push the image to"
+        machine_type: "GCloud machine type to use for the build"
     }
 
     command {
@@ -22,7 +24,12 @@ task build_and_push {
         git clone ${repo_url} .
         git checkout ${commit_hash}
         echo -n "" >> .gcloudignore
-        gcloud builds submit --tag ${registry_host}/${software_name}:${commit_hash} --timeout=24h
+        if [ -z ${machine_type} ]
+        then
+            gcloud builds submit --tag ${registry_host}/${software_name}:${commit_hash} --timeout=24h
+        else
+            gcloud builds submit --tag ${registry_host}/${software_name}:${commit_hash} --timeout=24h --machine-type ${machine_type}
+        fi
     }
 
     runtime {
@@ -38,6 +45,7 @@ workflow docker_build {
         String software_name
         String commit_hash
         String registry_host
+        String machine_type = ""
     }
 
     parameter_meta {
@@ -45,6 +53,7 @@ workflow docker_build {
         software_name: "The name that will be used to name the docker image"
         commit_hash: "The hash for the commit to build from; will also be used to tag the image"
         registry_host: "The docker repository to push the image to"
+        machine_type: "GCloud machine type to use for the build"
     }
 
     call build_and_push {
@@ -52,7 +61,8 @@ workflow docker_build {
             repo_url = repo_url,
             software_name = software_name,
             commit_hash = commit_hash,
-            registry_host = registry_host
+            registry_host = registry_host,
+            machine_type = machine_type
     }
 
     output {

--- a/scripts/wdl/docker_build_with_github_auth.wdl
+++ b/scripts/wdl/docker_build_with_github_auth.wdl
@@ -11,6 +11,7 @@ task build_and_push {
         File github_pass_encrypted
         String gcloud_kms_keyring
         String gcloud_kms_key
+        String machine_type
     }
 
     command <<<
@@ -23,7 +24,12 @@ task build_and_push {
         git clone ~{repo_url} .
         git checkout ~{commit_hash}
         echo -n "" >> .gcloudignore
-        gcloud builds submit --tag ~{registry_host}/~{software_name}:~{commit_hash} --timeout=24h
+        if [ -z ~{machine_type} ]
+        then
+            gcloud builds submit --tag ~{registry_host}/~{software_name}:~{commit_hash} --timeout=24h
+        else
+            gcloud builds submit --tag ~{registry_host}/~{software_name}:~{commit_hash} --timeout=24h --machine-type ~{machine_type}
+        fi
     >>>
 
     runtime {
@@ -43,6 +49,7 @@ workflow docker_build {
         File github_pass_encrypted # The location of the Google Cloud KMS encrypted password or personal access token for github authentication
         String gcloud_kms_keyring # The name of the Google Cloud KMS keyring used to encrypt github_pass_encrypted
         String gcloud_kms_key # The name of the Google Cloud KMS key used to encrypt github_pass_encrypted
+        String machine_type = "" # Optional machine type param to supply to google cloud build
     }
 
     call build_and_push {
@@ -54,7 +61,8 @@ workflow docker_build {
             github_user = github_user,
             github_pass_encrypted = github_pass_encrypted,
             gcloud_kms_keyring = gcloud_kms_keyring,
-            gcloud_kms_key = gcloud_kms_key
+            gcloud_kms_key = gcloud_kms_key,
+            machine_type = machine_type
     }
 
     output {

--- a/scripts/wdl/docker_build_with_github_auth.wdl
+++ b/scripts/wdl/docker_build_with_github_auth.wdl
@@ -33,7 +33,7 @@ task build_and_push {
     >>>
 
     runtime {
-        docker: "google/cloud-sdk:307.0.0"
+        docker: "google/cloud-sdk:392.0.0"
     }
 
 }

--- a/src/custom_sql_types.rs
+++ b/src/custom_sql_types.rs
@@ -193,6 +193,12 @@ pub enum MachineTypeEnum {
     #[serde(rename = "n1-highcpu-32")]
     #[db_rename = "n1-highcpu-32"]
     N1HighCpu32,
+    #[serde(rename = "e2-highcpu-8")]
+    #[db_rename = "e2-highcpu-8"]
+    E2HighCpu8,
+    #[serde(rename = "e2-highcpu-32")]
+    #[db_rename = "e2-highcpu-32"]
+    E2HighCpu32,
     #[serde(rename = "standard")]
     #[db_rename = "standard"]
     Standard,
@@ -203,6 +209,8 @@ impl fmt::Display for MachineTypeEnum {
         match self {
             MachineTypeEnum::N1HighCpu8 => write!(f, "n1-highcpu-8"),
             MachineTypeEnum::N1HighCpu32 => write!(f, "n1-highcpu-32"),
+            MachineTypeEnum::E2HighCpu8 => write!(f, "e2-highcpu-8"),
+            MachineTypeEnum::E2HighCpu32 => write!(f, "e2-highcpu-32"),
             MachineTypeEnum::Standard => write!(f, "standard"),
         }
     }

--- a/src/custom_sql_types.rs
+++ b/src/custom_sql_types.rs
@@ -173,3 +173,31 @@ pub enum EntityTypeEnum {
     Template,
     Test,
 }
+
+/// Maps to the custom type `machine_type_enum` in the DB
+///
+/// Represents the enum used in the DB for representing google cloud build's machine_type option
+/// for building on a different machine than the default
+#[derive(Debug, PartialEq, DbEnum, Serialize, Deserialize, Clone, Copy)]
+#[DieselType = "Machine_type_enum"]
+pub enum MachineTypeEnum {
+    #[serde(rename = "n1-highcpu-8")]
+    #[db_rename = "n1-highcpu-8"]
+    N1HighCpu8,
+    #[serde(rename = "n1-highcpu-32")]
+    #[db_rename = "n1-highcpu-32"]
+    N1HighCpu32,
+    #[serde(rename = "standard")]
+    #[db_rename = "standard"]
+    Standard,
+}
+
+impl fmt::Display for MachineTypeEnum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MachineTypeEnum::N1HighCpu8 => write!(f, "n1-highcpu-8"),
+            MachineTypeEnum::N1HighCpu32 => write!(f, "n1-highcpu-32"),
+            MachineTypeEnum::Standard => write!(f, "standard"),
+        }
+    }
+}

--- a/src/custom_sql_types.rs
+++ b/src/custom_sql_types.rs
@@ -178,6 +178,12 @@ pub enum EntityTypeEnum {
 ///
 /// Represents the enum used in the DB for representing google cloud build's machine_type option
 /// for building on a different machine than the default
+///
+/// Google's Cloud Build docs explain the machine-type argument here:
+/// https://cloud.google.com/sdk/gcloud/reference/builds/submit#--machine-type
+/// Notably, it mentions two other machine types: e2-highcpu-8 and e2-highcpu-32, but, when I
+/// tested building with those, I got an error message saying the machine-type was
+/// unrecognized so ¯\_(ツ)_/¯
 #[derive(Debug, PartialEq, DbEnum, Serialize, Deserialize, Clone, Copy)]
 #[DieselType = "Machine_type_enum"]
 pub enum MachineTypeEnum {

--- a/src/manager/gcloud_subscriber.rs
+++ b/src/manager/gcloud_subscriber.rs
@@ -366,7 +366,9 @@ impl GCloudSubscriber {
 mod tests {
 
     use crate::config::{GCloudConfig, GithubConfig};
-    use crate::custom_sql_types::{BuildStatusEnum, EntityTypeEnum, RunStatusEnum};
+    use crate::custom_sql_types::{
+        BuildStatusEnum, EntityTypeEnum, MachineTypeEnum, RunStatusEnum,
+    };
     use crate::db::DbPool;
     use crate::manager::gcloud_subscriber::{GCloudSubscriber, ParseMessageError};
     use crate::manager::github_runner::GithubRunner;
@@ -488,6 +490,7 @@ mod tests {
             name: String::from("TestSoftware"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/manager/github_runner.rs
+++ b/src/manager/github_runner.rs
@@ -221,7 +221,9 @@ impl GithubRunner {
 #[cfg(test)]
 mod tests {
     use crate::config::{EmailConfig, EmailSendmailConfig};
-    use crate::custom_sql_types::{BuildStatusEnum, EntityTypeEnum, RunStatusEnum};
+    use crate::custom_sql_types::{
+        BuildStatusEnum, EntityTypeEnum, MachineTypeEnum, RunStatusEnum,
+    };
     use crate::manager::github_runner::{GithubRunRequest, GithubRunner};
     use crate::manager::notification_handler::NotificationHandler;
     use crate::manager::test_runner::TestRunner;
@@ -339,6 +341,7 @@ mod tests {
             name: String::from("TestSoftware"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -1316,7 +1316,7 @@ impl StatusManager {
 mod tests {
 
     use crate::custom_sql_types::{
-        BuildStatusEnum, ReportStatusEnum, ResultTypeEnum, RunStatusEnum,
+        BuildStatusEnum, MachineTypeEnum, ReportStatusEnum, ResultTypeEnum, RunStatusEnum,
     };
     use crate::db::DbPool;
     use crate::manager::notification_handler::NotificationHandler;
@@ -1563,6 +1563,7 @@ mod tests {
             name: String::from("Kevin's Software3"),
             description: Some(String::from("Kevin even made this software for testing")),
             repository_url: String::from("https://example.com/organization/project3"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin3@example.com")),
         };
 
@@ -1592,6 +1593,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("test_send_email@example.com")),
         };
 

--- a/src/manager/test_runner.rs
+++ b/src/manager/test_runner.rs
@@ -1027,7 +1027,7 @@ pub fn run_finished_building(conn: &PgConnection, run_id: Uuid) -> Result<RunBui
 
 #[cfg(test)]
 mod tests {
-    use crate::custom_sql_types::{BuildStatusEnum, RunStatusEnum};
+    use crate::custom_sql_types::{BuildStatusEnum, MachineTypeEnum, RunStatusEnum};
     use crate::manager::test_runner::{run_finished_building, Error, RunBuildStatus, TestRunner};
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::run::{NewRun, RunData};
@@ -1118,6 +1118,7 @@ mod tests {
             name: String::from("TestSoftware"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -1189,6 +1190,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/models/run.rs
+++ b/src/models/run.rs
@@ -724,7 +724,7 @@ impl RunWithResultsAndErrorsData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::custom_sql_types::ResultTypeEnum;
+    use crate::custom_sql_types::{MachineTypeEnum, ResultTypeEnum};
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::result::{NewResult, ResultData};
     use crate::models::run_error::{NewRunError, RunErrorQuery};
@@ -1121,6 +1121,7 @@ mod tests {
             name: String::from("Kevin's Software2"),
             description: Some(String::from("Kevin made this software for testing also")),
             repository_url: String::from("https://example.com/organization/project2"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/models/run_software_version.rs
+++ b/src/models/run_software_version.rs
@@ -169,7 +169,7 @@ impl RunSoftwareVersionData {
 mod tests {
 
     use super::*;
-    use crate::custom_sql_types::RunStatusEnum;
+    use crate::custom_sql_types::{MachineTypeEnum, RunStatusEnum};
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::run::{NewRun, RunData};
     use crate::models::software::{NewSoftware, SoftwareData};
@@ -242,6 +242,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -306,6 +307,7 @@ mod tests {
             name: String::from("Kevin's Software2"),
             description: Some(String::from("Kevin made this software for testing also")),
             repository_url: String::from("https://example.com/organization/project2"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/models/software_build.rs
+++ b/src/models/software_build.rs
@@ -278,7 +278,7 @@ impl SoftwareBuildData {
 mod tests {
 
     use super::*;
-    use crate::custom_sql_types::RunStatusEnum;
+    use crate::custom_sql_types::{MachineTypeEnum, RunStatusEnum};
     use crate::models::pipeline::{NewPipeline, PipelineData};
     use crate::models::run::{NewRun, RunData};
     use crate::models::run_software_version::{NewRunSoftwareVersion, RunSoftwareVersionData};
@@ -295,6 +295,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -347,6 +348,7 @@ mod tests {
             name: String::from("Kevin's Other Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project2"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/routes/run.rs
+++ b/src/routes/run.rs
@@ -9,6 +9,7 @@ use crate::manager::test_runner;
 use crate::manager::test_runner::TestRunner;
 use crate::models::run::{DeleteError, RunData, RunQuery, RunWithResultsAndErrorsData};
 use crate::routes::error_handling::{default_500, ErrorBody};
+use crate::routes::util::parse_id;
 use crate::util::run_csv;
 use actix_web::dev::HttpResponseBuilder;
 use actix_web::http::StatusCode;
@@ -22,7 +23,6 @@ use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use uuid::Uuid;
-use crate::routes::util::parse_id;
 
 /// Optional query parameters for the find_by_id mapping
 #[derive(Deserialize, Debug)]
@@ -196,7 +196,7 @@ async fn find_for_test(
     // Parse ID into Uuid
     let id = match parse_id(&*id) {
         Ok(id) => id,
-        Err(error_response) => return error_response
+        Err(error_response) => return error_response,
     };
 
     let return_csvs: bool = query.csv;
@@ -228,7 +228,7 @@ async fn find_for_template(
     // Parse ID into Uuid
     let id = match parse_id(&*id) {
         Ok(id) => id,
-        Err(error_response) => return error_response
+        Err(error_response) => return error_response,
     };
 
     let return_csvs: bool = query.csv;
@@ -260,7 +260,7 @@ async fn find_for_pipeline(
     // Parse ID into Uuid
     let id = match parse_id(&*id) {
         Ok(id) => id,
-        Err(error_response) => return error_response
+        Err(error_response) => return error_response,
     };
 
     let return_csvs: bool = query.csv;
@@ -277,11 +277,7 @@ async fn find_for_pipeline(
 /// appropriate HttpResponse containing either the retrieved run data (as binary data for a zip of
 /// csvs containing the data if `return_csvs` or as json if not) or an error message and status code
 /// if there is an error
-async fn find(
-    run_query: RunQuery,
-    return_csvs: bool,
-    pool: web::Data<db::DbPool>,
-) -> HttpResponse {
+async fn find(run_query: RunQuery, return_csvs: bool, pool: web::Data<db::DbPool>) -> HttpResponse {
     // Query DB for runs in new thread
     match web::block(move || {
         let conn = pool.get().expect("Failed to get DB connection from pool");
@@ -311,7 +307,7 @@ async fn find(
                     // Build csv files from results
                     match get_bytes_for_csv_zip_from_runs(&results) {
                         Ok(zip_bytes) => HttpResponse::Ok().body(zip_bytes),
-                        Err(error_response) => error_response
+                        Err(error_response) => error_response,
                     }
                 }
                 // Otherwise, just return the json

--- a/src/routes/software.rs
+++ b/src/routes/software.rs
@@ -280,6 +280,7 @@ fn init_routes_software_building_disabled(cfg: &mut web::ServiceConfig) {
 mod tests {
 
     use super::*;
+    use crate::custom_sql_types::MachineTypeEnum;
     use crate::routes::error_handling::ErrorBody;
     use crate::unit_test_util::*;
     use crate::util::git_repos::GitRepoChecker;
@@ -292,6 +293,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("git://example.com/example/example.git"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -516,6 +518,7 @@ mod tests {
             name: String::from("Kevin's test"),
             description: Some(String::from("Kevin's test description")),
             repository_url: String::from("https://github.com/broadinstitute/gatk.git"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -564,6 +567,7 @@ mod tests {
             name: software.name.clone(),
             description: Some(String::from("Kevin's test description")),
             repository_url: String::from("https://github.com/broadinstitute/gatk.git"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -601,6 +605,7 @@ mod tests {
             name: software.name.clone(),
             description: Some(String::from("Kevin's test description")),
             repository_url: String::from("git://example.com/example/example.git"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -638,6 +643,7 @@ mod tests {
             name: String::from("Kevin's test"),
             description: Some(String::from("Kevin's test description")),
             repository_url: String::from("https://github.com/broadinstitute/gatk.git"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 
@@ -673,6 +679,7 @@ mod tests {
         let software_change = SoftwareChangeset {
             name: Some(String::from("Kevin's test change")),
             description: Some(String::from("Kevin's test description2")),
+            machine_type: Some(MachineTypeEnum::N1HighCpu32),
         };
 
         let req = test::TestRequest::put()
@@ -693,6 +700,10 @@ mod tests {
                 .expect("Created software missing description"),
             software_change.description.unwrap()
         );
+        assert_eq!(
+            test_software.machine_type,
+            software_change.machine_type.unwrap()
+        );
     }
 
     #[actix_rt::test]
@@ -711,6 +722,7 @@ mod tests {
         let software_change = SoftwareChangeset {
             name: Some(String::from("Kevin's test change")),
             description: Some(String::from("Kevin's test description2")),
+            machine_type: Some(MachineTypeEnum::N1HighCpu32),
         };
 
         let req = test::TestRequest::put()
@@ -746,6 +758,7 @@ mod tests {
         let software_change = SoftwareChangeset {
             name: Some(String::from("Kevin's test change")),
             description: Some(String::from("Kevin's test description2")),
+            machine_type: Some(MachineTypeEnum::N1HighCpu32),
         };
 
         let req = test::TestRequest::put()
@@ -780,6 +793,7 @@ mod tests {
         let software_change = SoftwareChangeset {
             name: Some(String::from("Kevin's test change")),
             description: Some(String::from("Kevin's test description2")),
+            machine_type: Some(MachineTypeEnum::N1HighCpu32),
         };
 
         let req = test::TestRequest::put()

--- a/src/routes/software_build.rs
+++ b/src/routes/software_build.rs
@@ -149,7 +149,7 @@ fn init_routes_software_building_disabled(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::custom_sql_types::BuildStatusEnum;
+    use crate::custom_sql_types::{BuildStatusEnum, MachineTypeEnum};
     use crate::models::software::{NewSoftware, SoftwareData};
     use crate::models::software_build::NewSoftwareBuild;
     use crate::models::software_version::{NewSoftwareVersion, SoftwareVersionData};
@@ -163,6 +163,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/routes/software_version.rs
+++ b/src/routes/software_version.rs
@@ -149,6 +149,7 @@ fn init_routes_software_building_disabled(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::custom_sql_types::MachineTypeEnum;
     use crate::models::software::{NewSoftware, SoftwareData};
     use crate::models::software_version::NewSoftwareVersion;
     use crate::unit_test_util::*;
@@ -161,6 +162,7 @@ mod tests {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
             repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
             created_by: Some(String::from("Kevin@example.com")),
         };
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -146,11 +146,14 @@ table! {
 
 table! {
     use diesel::sql_types::*;
+    use crate::custom_sql_types::Machine_type_enum;
+
     software(software_id) {
         software_id -> Uuid,
         name -> Text,
         description -> Nullable<Text>,
         repository_url -> Text,
+        machine_type -> Machine_type_enum,
         created_at -> Timestamptz,
         created_by -> Nullable<Text>,
     }


### PR DESCRIPTION
Google Cloud Build allows specifying a machine type to use for running the build.  It has become clear that it is necessary to allow the user to specify this for their software builds because the recent gatk builds have failed because of OOM errors.

This is implemented by added a `machine_type` column to `software`, which corresponds to the different options for machine types allowed by google cloud build.  If a value other than `standard` is specified when creating/updating a software, builds for that software will use the specified machine type.