### PR TITLE
Added tracking of tags for software

### DIFF
--- a/carrot.example.yml
+++ b/carrot.example.yml
@@ -76,6 +76,8 @@ custom_image_build:
     kms_keyring: example-key-ring
     # The GCloud KMS key for decrypting `client_pass_uri`
     kms_key: example-key
+  # The local directory where metadata-only clones of software repos will be kept for keeping track of tags and commits
+  repo_cache_location: ~/carrot/repos
 # Config for validating parts of a test
 validation:
   # The location of the womtool jar to use to validate WDLs

--- a/carrot.example.yml
+++ b/carrot.example.yml
@@ -20,7 +20,7 @@ status_manager:
 wdl_storage:
   # Use local if you want to store in a local directory
   local:
-    wdl_location: ~/carrot/wdl
+    wdl_location: ~/.carrot/wdl
   # Use gcs if you want to store in a gcs location
   # gcs:
     # wdl_location: gs://example.com/example/dir
@@ -77,7 +77,7 @@ custom_image_build:
     # The GCloud KMS key for decrypting `client_pass_uri`
     kms_key: example-key
   # The local directory where metadata-only clones of software repos will be kept for keeping track of tags and commits
-  repo_cache_location: ~/carrot/repos
+  repo_cache_location: ~/.carrot/repos
 # Config for validating parts of a test
 validation:
   # The location of the womtool jar to use to validate WDLs

--- a/carrot_cli/src/carrot_cli/rest/software_versions.py
+++ b/carrot_cli/src/carrot_cli/rest/software_versions.py
@@ -16,6 +16,8 @@ def find(
     commit,
     created_before,
     created_after,
+    committed_before,
+    committed_after,
     sort,
     limit,
     offset,
@@ -28,8 +30,16 @@ def find(
         ("commit", commit),
         ("created_before", created_before),
         ("created_after", created_after),
+        ("committed_before", committed_before),
+        ("committed_after", committed_after),
         ("sort", sort),
         ("limit", limit),
         ("offset", offset),
     ]
     return request_handler.find("software_versions", params)
+
+def update(
+    software_version_id
+):
+    """Submits a request to CARROT's software_versions update mapping"""
+    return request_handler.update("software_versions", software_version_id, [])

--- a/carrot_cli/src/carrot_cli/software/software_version/command.py
+++ b/carrot_cli/src/carrot_cli/software/software_version/command.py
@@ -52,6 +52,18 @@ def find_by_id(id):
     "YYYY-MM-DDThh:mm:ss.ssssss",
 )
 @click.option(
+    "--committed_before",
+    default="",
+    help="Upper bound for software version's commit_date value, in the format "
+         "YYYY-MM-DDThh:mm:ss.ssssss",
+)
+@click.option(
+    "--committed_after",
+    default="",
+    help="Lower bound for software version's commit_date value, in the format "
+         "YYYY-MM-DDThh:mm:ss.ssssss",
+)
+@click.option(
     "--sort",
     default=None,
     type=str,
@@ -78,6 +90,8 @@ def find(
     commit,
     created_before,
     created_after,
+    committed_before,
+    committed_after,
     sort,
     limit,
     offset,
@@ -95,11 +109,20 @@ def find(
             commit,
             created_before,
             created_after,
+            committed_before,
+            committed_after,
             sort,
             limit,
             offset,
         )
     )
 
+@main.command(name="update")
+@click.argument("id")
+def update(
+    id
+):
+    """Refreshes the commit, commit_date, and tags for the software_version specified by ID"""
+    print(software_versions.update(id))
 
 main.add_command(software_build.main)

--- a/carrot_cli/src/carrot_cli/software/software_version/command.py
+++ b/carrot_cli/src/carrot_cli/software/software_version/command.py
@@ -53,13 +53,15 @@ def find_by_id(id):
 )
 @click.option(
     "--committed_before",
-    default="",
+    default=None,
+    type=str,
     help="Upper bound for software version's commit_date value, in the format "
          "YYYY-MM-DDThh:mm:ss.ssssss",
 )
 @click.option(
     "--committed_after",
-    default="",
+    default=None,
+    type=str,
     help="Lower bound for software version's commit_date value, in the format "
          "YYYY-MM-DDThh:mm:ss.ssssss",
 )

--- a/carrot_cli/tests/unit/rest/test_software_versions.py
+++ b/carrot_cli/tests/unit/rest/test_software_versions.py
@@ -19,8 +19,10 @@ def unstub():
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                    "commit_date": "2020-09-10T18:48:06.371563",
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "tags": []
                 },
                 indent=4,
                 sort_keys=True,
@@ -64,6 +66,8 @@ def test_find_by_id(find_by_id_data):
                 ("commit", "ca82a6dff817ec66f44342007202690a93763949"),
                 ("created_before", ""),
                 ("created_after", ""),
+                ("committed_before", ""),
+                ("committed_after", ""),
                 ("sort", ""),
                 ("limit", ""),
                 ("offset", ""),
@@ -73,8 +77,10 @@ def test_find_by_id(find_by_id_data):
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
                         "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                        "commit_date": "2020-09-10T18:48:06.371563",
                         "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                        "tags": []
                     }
                 ],
                 indent=4,
@@ -88,6 +94,8 @@ def test_find_by_id(find_by_id_data):
                 ("commit", "ca82a6dff817ec66f44342007202690a93763949"),
                 ("created_before", ""),
                 ("created_after", ""),
+                ("committed_before", ""),
+                ("committed_after", ""),
                 ("sort", ""),
                 ("limit", ""),
                 ("offset", ""),
@@ -124,5 +132,52 @@ def test_find(find_data):
         find_data["params"][5][1],
         find_data["params"][6][1],
         find_data["params"][7][1],
+        find_data["params"][8][1],
+        find_data["params"][9][1],
     )
     assert result == find_data["return"]
+
+@pytest.fixture(
+    params=[
+        {
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                    "commit_date": "2020-09-10T18:48:06.371563",
+                    "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "tags": ["tag1", "tag2"]
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+        },
+        {
+            "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            "return": json.dumps(
+                {
+                    "title": "No software_version found",
+                    "status": 404,
+                    "detail": "No software_version found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+        },
+    ]
+)
+def update_data(request):
+    # Set all requests to return None so only the one we expect will return a value
+    mockito.when(request_handler).update(...).thenReturn(None)
+    # Mock up request response
+    mockito.when(request_handler).update(
+        "software_versions", request.param["id"], []
+    ).thenReturn(request.param["return"])
+    return request.param
+
+
+def test_update(update_data):
+    result = software_versions.update(update_data["id"])
+    assert result == update_data["return"]

--- a/carrot_cli/tests/unit/software/software_version/test_software_version_command.py
+++ b/carrot_cli/tests/unit/software/software_version/test_software_version_command.py
@@ -27,8 +27,10 @@ def unstub():
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                    "commit_date": "2020-09-10T18:48:06.371563",
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "tags": []
                 },
                 indent=4,
                 sort_keys=True,
@@ -86,6 +88,10 @@ def test_find_by_id(find_by_id_data):
                 "2020-10-00T00:00:00.000000",
                 "--created_after",
                 "2020-09-00T00:00:00.000000",
+                "--committed_before",
+                "2020-11-00T00:00:00.000000",
+                "--committed_after",
+                "2020-08-00T00:00:00.000000",
                 "--sort",
                 "asc(commit)",
                 "--limit",
@@ -99,6 +105,8 @@ def test_find_by_id(find_by_id_data):
                 "ca82a6dff817ec66f44342007202690a93763949",
                 "2020-10-00T00:00:00.000000",
                 "2020-09-00T00:00:00.000000",
+                "2020-11-00T00:00:00.000000",
+                "2020-08-00T00:00:00.000000",
                 "asc(commit)",
                 1,
                 0,
@@ -108,8 +116,10 @@ def test_find_by_id(find_by_id_data):
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
                         "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                        "commit_date": "2020-09-10T18:48:06.371563",
                         "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                        "tags": ["tag1"]
                     }
                 ],
                 indent=4,
@@ -131,6 +141,10 @@ def test_find_by_id(find_by_id_data):
                 "2020-10-00T00:00:00.000000",
                 "--created_after",
                 "2020-09-00T00:00:00.000000",
+                "--committed_before",
+                "2020-11-00T00:00:00.000000",
+                "--committed_after",
+                "2020-08-00T00:00:00.000000",
                 "--sort",
                 "asc(commit)",
                 "--limit",
@@ -144,6 +158,8 @@ def test_find_by_id(find_by_id_data):
                 "ca82a6dff817ec66f44342007202690a93763949",
                 "2020-10-00T00:00:00.000000",
                 "2020-09-00T00:00:00.000000",
+                "2020-11-00T00:00:00.000000",
+                "2020-08-00T00:00:00.000000",
                 "asc(commit)",
                 1,
                 0,
@@ -170,8 +186,10 @@ def test_find_by_id(find_by_id_data):
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
                         "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                        "commit_date": "2020-09-10T18:48:06.371563",
                         "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                        "tags": ["hi"]
                     }
                 ],
                 indent=4,
@@ -188,6 +206,8 @@ def test_find_by_id(find_by_id_data):
             ],
             "params": [
                 "986325ba-06fe-4b1a-9e96-47d4f36bf819",
+                None,
+                None,
                 None,
                 None,
                 None,
@@ -228,6 +248,8 @@ def find_data(request):
         request.param["params"][5],
         request.param["params"][6],
         request.param["params"][7],
+        request.param["params"][8],
+        request.param["params"][9],
     ).thenReturn(request.param["return"])
     return request.param
 
@@ -236,3 +258,59 @@ def test_find(find_data):
     runner = CliRunner()
     test_software_version = runner.invoke(carrot, find_data["args"])
     assert test_software_version.output == find_data["return"] + "\n"
+
+@pytest.fixture(
+    params=[
+        {
+            "args": [
+                "software",
+                "version",
+                "update",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            ],
+            "return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "commit": "ca82a6dff817ec66f44342007202690a93763949",
+                    "commit_date": "2020-09-10T18:48:06.371563",
+                    "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "tags": ["tag1"]
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+        },
+        {
+            "args": [
+                "software",
+                "version",
+                "update",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            ],
+            "return": json.dumps(
+                {
+                    "title": "No software_version found",
+                    "status": 404,
+                    "detail": "No software_version found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+        },
+    ]
+)
+def update_data(request):
+    # Set all requests to return None so only the one we expect will return a value
+    mockito.when(software_versions).update(...).thenReturn(None)
+    # Mock up request response
+    mockito.when(software_versions).update(request.param["args"][3]).thenReturn(
+        request.param["return"]
+    )
+    return request.param
+
+
+def test_update(update_data):
+    runner = CliRunner()
+    test_software_version = runner.invoke(carrot, update_data["args"])
+    assert test_software_version.output == update_data["return"] + "\n"

--- a/migrations/2022-10-27-192932_software_version_tags/down.sql
+++ b/migrations/2022-10-27-192932_software_version_tags/down.sql
@@ -1,0 +1,6 @@
+drop view if exists software_version_with_tags;
+
+drop table if exists software_version_tag;
+
+alter table software_version
+    drop column if exists commit_date;

--- a/migrations/2022-10-27-192932_software_version_tags/up.sql
+++ b/migrations/2022-10-27-192932_software_version_tags/up.sql
@@ -1,0 +1,14 @@
+create table software_version_tag(
+    software_version_id uuid not null references software_version(software_version_id),
+    tag text not null,
+    created_at timestamptz not null default current_timestamp,
+    primary key(software_version_id, tag)
+);
+
+alter table software_version
+    add column commit_date timestamptz not null default to_timestamp(0);
+
+create view software_version_with_tags as
+    select software_version_id, software_id, commit, commit_date, coalesce(array_agg(tag) filter (where tag is not null), '{}') as tags, software_version.created_at as created_at
+    from software_version left outer join software_version_tag using (software_version_id)
+    group by software_version_id;

--- a/src/config.rs
+++ b/src/config.rs
@@ -286,9 +286,7 @@ impl Default for StatusManagerConfig {
 }
 
 impl StatusManagerConfig {
-    pub fn new(
-        status_check_wait_time_in_secs: u64,
-    ) -> Self {
+    pub fn new(status_check_wait_time_in_secs: u64) -> Self {
         StatusManagerConfig {
             status_check_wait_time_in_secs,
         }
@@ -577,16 +575,21 @@ pub struct CustomImageBuildConfig {
     image_registry_host: String,
     /// Config for accessing private github repos, if wanted
     private_github_access: Option<PrivateGithubAccessConfig>,
+    /// The directory where local copies of the github repos will be kept for checking commits/tags
+    #[serde(default = "repo_cache_location_default")]
+    repo_cache_location: String,
 }
 
 impl CustomImageBuildConfig {
     pub fn new(
         image_registry_host: String,
         private_github_access: Option<PrivateGithubAccessConfig>,
+        repo_cache_location: String,
     ) -> Self {
         CustomImageBuildConfig {
             image_registry_host,
             private_github_access,
+            repo_cache_location,
         }
     }
     pub fn image_registry_host(&self) -> &String {
@@ -595,6 +598,21 @@ impl CustomImageBuildConfig {
     pub fn private_github_access(&self) -> Option<&PrivateGithubAccessConfig> {
         self.private_github_access.as_ref()
     }
+    pub fn repo_cache_location(&self) -> &String {
+        &self.repo_cache_location
+    }
+}
+
+// Function for providing the default value
+fn repo_cache_location_default() -> String {
+    let mut current_dir = std::env::current_dir()
+        .expect("Failed to get current directory for git repo cache directory default");
+    current_dir.push("carrot");
+    current_dir.push("repos");
+    current_dir
+        .to_str()
+        .expect("Failed to convert git repo cache directory path to string")
+        .to_string()
 }
 
 /// Config for accessing private github repos

--- a/src/config.rs
+++ b/src/config.rs
@@ -476,7 +476,7 @@ impl LocalWdlStorageConfig {
 fn wdl_location_default() -> String {
     let mut current_dir =
         std::env::current_dir().expect("Failed to get current directory for wdl directory default");
-    current_dir.push("carrot");
+    current_dir.push(".carrot");
     current_dir.push("wdl");
     current_dir
         .to_str()
@@ -607,7 +607,7 @@ impl CustomImageBuildConfig {
 fn repo_cache_location_default() -> String {
     let mut current_dir = std::env::current_dir()
         .expect("Failed to get current directory for git repo cache directory default");
-    current_dir.push("carrot");
+    current_dir.push(".carrot");
     current_dir.push("repos");
     current_dir
         .to_str()

--- a/src/manager/gcloud_subscriber.rs
+++ b/src/manager/gcloud_subscriber.rs
@@ -4,7 +4,7 @@
 //! contains messages for starting test runs.  Should poll the subscription on a schedule and
 //! process any messages it finds by starting test runs as specified in the messages
 
-use crate::config::{Config, GCloudConfig, GithubConfig};
+use crate::config::{Config, GCloudConfig, GithubConfig, PrivateGithubAccessConfig};
 use crate::db::DbPool;
 use crate::manager::github::{GithubPrRequest, GithubRunRequest, GithubRunner};
 use crate::manager::notification_handler::NotificationHandler;
@@ -16,6 +16,7 @@ use crate::requests::cromwell_requests::CromwellClient;
 use crate::requests::gcloud_storage::GCloudClient;
 use crate::requests::github_requests::GithubClient;
 use crate::requests::test_resource_requests::TestResourceClient;
+use crate::util::git_repos::GitRepoManager;
 use actix_web::client::Client;
 use base64;
 use diesel::PgConnection;
@@ -155,12 +156,21 @@ pub async fn init_and_run(
         CromwellClient::new(http_client.clone(), carrot_config.cromwell().address());
     // Create a test runner
     let test_runner: TestRunner = match carrot_config.custom_image_build() {
-        Some(image_build_config) => TestRunner::new(
-            cromwell_client,
-            test_resource_client,
-            Some(image_build_config.image_registry_host()),
-        ),
-        None => TestRunner::new(cromwell_client, test_resource_client, None),
+        Some(image_build_config) => {
+            let git_repo_manager = GitRepoManager::new(
+                image_build_config
+                    .private_github_access()
+                    .map(PrivateGithubAccessConfig::to_owned),
+                image_build_config.repo_cache_location().to_owned(),
+            );
+            TestRunner::new(
+                cromwell_client,
+                test_resource_client,
+                Some(image_build_config.image_registry_host()),
+                Some(git_repo_manager),
+            )
+        }
+        None => TestRunner::new(cromwell_client, test_resource_client, None, None),
     };
     let gcloud_subscriber: GCloudSubscriber = GCloudSubscriber::new(
         db_pool,
@@ -410,7 +420,11 @@ mod tests {
     use crate::requests::gcloud_storage::GCloudClient;
     use crate::requests::github_requests::GithubClient;
     use crate::requests::test_resource_requests::TestResourceClient;
-    use crate::unit_test_util::{get_test_db_connection, get_test_db_pool, load_default_config};
+    use crate::unit_test_util::{
+        get_test_db_connection, get_test_db_pool, get_test_remote_github_repo,
+        get_test_test_runner_building_disabled, get_test_test_runner_building_enabled,
+        insert_test_software_with_repo, load_default_config,
+    };
     use actix_web::client::Client;
     use diesel::PgConnection;
     use google_pubsub1::{PubsubMessage, ReceivedMessage};
@@ -549,12 +563,8 @@ mod tests {
             CromwellClient::new(http_client.clone(), carrot_config.cromwell().address());
         // Create a test runner
         let test_runner: TestRunner = match carrot_config.custom_image_build() {
-            Some(image_build_config) => TestRunner::new(
-                cromwell_client,
-                test_resource_client,
-                Some(image_build_config.image_registry_host()),
-            ),
-            None => TestRunner::new(cromwell_client, test_resource_client, None),
+            Some(_) => get_test_test_runner_building_enabled(),
+            None => get_test_test_runner_building_disabled(),
         };
         GCloudSubscriber::new(
             db_pool,
@@ -580,6 +590,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -624,14 +636,15 @@ mod tests {
             "test_process_request_success",
         );
 
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, _, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
 
         let request_data_json = json! ({
             "test_name": test_test.name,
             "test_input_key": "in_test_image",
             "eval_input_key": "in_eval_image",
             "software_name": test_software.name,
-            "commit": "764a00442ddb412eed331655cfd90e151f580518",
+            "commit": &commit1,
             "owner":"TestOwner",
             "repo":"TestRepo",
             "issue_number":4,
@@ -659,8 +672,10 @@ mod tests {
             delivery_attempt: Some(1),
         };
 
-        let test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
+        let test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit1) });
 
         test_gcloud_subscriber
             .start_run_from_message(&conn, &received_message)
@@ -704,7 +719,7 @@ mod tests {
         assert_run_mapped_to_software_with_commit(
             &conn,
             test_run.run_id,
-            "764a00442ddb412eed331655cfd90e151f580518",
+            &commit1,
             test_software.software_id,
         );
 
@@ -721,7 +736,8 @@ mod tests {
             "test_process_request_success",
         );
 
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, _, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
 
         let request_data_json = json! ({
             "request_type": "run",
@@ -730,7 +746,7 @@ mod tests {
                 "test_input_key": "in_test_image",
                 "eval_input_key": "in_eval_image",
                 "software_name": test_software.name,
-                "commit": "764a00442ddb412eed331655cfd90e151f580518",
+                "commit": &commit1,
                 "owner":"TestOwner",
                 "repo":"TestRepo",
                 "issue_number":4,
@@ -759,8 +775,10 @@ mod tests {
             delivery_attempt: Some(1),
         };
 
-        let test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
+        let test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit1) });
 
         test_gcloud_subscriber
             .start_run_from_message(&conn, &received_message)
@@ -804,7 +822,7 @@ mod tests {
         assert_run_mapped_to_software_with_commit(
             &conn,
             test_run.run_id,
-            "764a00442ddb412eed331655cfd90e151f580518",
+            &commit1,
             test_software.software_id,
         );
 
@@ -820,7 +838,8 @@ mod tests {
             &conn,
             "test_process_request_success",
         );
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, commit2, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
 
         let request_data_json = json! ({
             "request_type": "pr",
@@ -829,8 +848,8 @@ mod tests {
                 "test_input_key": "in_test_image",
                 "eval_input_key": "in_eval_image",
                 "software_name": test_software.name,
-                "base_commit": "764a00442ddb412eed331655cfd90e151f580518",
-                "head_commit": "af9cbceb8388e2170881d17f5ca88833c5c37ed6",
+                "base_commit": &commit1,
+                "head_commit": &commit2,
                 "owner":"TestOwner",
                 "repo":"TestRepo",
                 "issue_number":4,
@@ -859,10 +878,14 @@ mod tests {
             delivery_attempt: Some(1),
         };
 
-        let base_test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let base_eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let head_test_params = json!({"in_test_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
-        let head_eval_params = json!({"in_eval_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
+        let base_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let base_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let head_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit2) });
+        let head_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit2) });
 
         test_gcloud_subscriber
             .start_run_from_message(&conn, &received_message)
@@ -923,13 +946,13 @@ mod tests {
         assert_run_mapped_to_software_with_commit(
             &conn,
             base_run.run_id,
-            "764a00442ddb412eed331655cfd90e151f580518",
+            &commit1,
             test_software.software_id,
         );
         assert_run_mapped_to_software_with_commit(
             &conn,
             head_run.run_id,
-            "af9cbceb8388e2170881d17f5ca88833c5c37ed6",
+            &commit2,
             test_software.software_id,
         );
 
@@ -945,7 +968,8 @@ mod tests {
             &conn,
             "test_process_request_success",
         );
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, commit2, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
 
         let request_data_json = json! ({
             "request_type": "pr",
@@ -954,8 +978,8 @@ mod tests {
                 "test_input_key": "in_test_image",
                 "eval_input_key": "in_eval_image",
                 "software_name": test_software.name,
-                "base_commit": "764a00442ddb412eed331655cfd90e151f580518",
-                "head_commit": "af9cbceb8388e2170881d17f5ca88833c5c37ed6",
+                "base_commit": &commit1,
+                "head_commit": &commit2,
                 "owner":"TestOwner",
                 "repo":"TestRepo",
                 "issue_number":4,
@@ -972,10 +996,14 @@ mod tests {
         let request_data_string = serde_json::to_string(&request_data_json).unwrap();
         let base64_request_data = base64::encode(&request_data_string);
 
-        let base_test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let base_eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let head_test_params = json!({"in_test_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
-        let head_eval_params = json!({"in_eval_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
+        let base_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let base_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let head_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit2) });
+        let head_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit2) });
 
         test_gcloud_subscriber
             .process_github_request_from_message(&conn, &base64_request_data)
@@ -1037,13 +1065,13 @@ mod tests {
         assert_run_mapped_to_software_with_commit(
             &conn,
             base_run.run_id,
-            "764a00442ddb412eed331655cfd90e151f580518",
+            &commit1,
             test_software.software_id,
         );
         assert_run_mapped_to_software_with_commit(
             &conn,
             head_run.run_id,
-            "af9cbceb8388e2170881d17f5ca88833c5c37ed6",
+            &commit2,
             test_software.software_id,
         );
 

--- a/src/manager/github/github_pr_request.rs
+++ b/src/manager/github/github_pr_request.rs
@@ -283,7 +283,10 @@ mod tests {
     use crate::requests::cromwell_requests::CromwellClient;
     use crate::requests::github_requests::GithubClient;
     use crate::requests::test_resource_requests::TestResourceClient;
-    use crate::unit_test_util::get_test_db_connection;
+    use crate::unit_test_util::{
+        get_test_db_connection, get_test_remote_github_repo, get_test_test_runner_building_enabled,
+        insert_test_software_with_repo,
+    };
     use actix_web::client::Client;
     use diesel::PgConnection;
     use mailparse::MailHeaderMap;
@@ -377,28 +380,6 @@ mod tests {
         TestData::create(&conn, new_test).expect("Failed to insert test")
     }
 
-    fn insert_test_software(conn: &PgConnection) -> SoftwareData {
-        let new_software = NewSoftware {
-            name: String::from("TestSoftware"),
-            description: Some(String::from("Kevin made this software for testing")),
-            repository_url: String::from("https://example.com/organization/project"),
-            machine_type: Some(MachineTypeEnum::Standard),
-            created_by: Some(String::from("Kevin@example.com")),
-        };
-
-        SoftwareData::create(conn, new_software).unwrap()
-    }
-
-    fn create_test_test_runner() -> TestRunner {
-        let cromwell_client = CromwellClient::new(Client::default(), &mockito::server_url());
-        let test_resource_client = TestResourceClient::new(Client::default(), None);
-        TestRunner::new(
-            cromwell_client,
-            test_resource_client,
-            Some("https://example.com"),
-        )
-    }
-
     fn create_test_notification_handler() -> NotificationHandler {
         // Create an emailer
         let test_email_config =
@@ -427,6 +408,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -464,7 +447,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_process_success() {
         let conn = get_test_db_connection();
-        let test_test_runner = create_test_test_runner();
+        let test_test_runner = get_test_test_runner_building_enabled();
         let test_notification_handler = create_test_notification_handler();
 
         let test_test = insert_test_test_with_subscriptions_with_entities(
@@ -472,15 +455,16 @@ mod tests {
             "test_process_pr_request_success",
         );
 
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, commit2, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
 
         let test_request = GithubPrRequest {
             test_name: test_test.name,
             test_input_key: Some(String::from("in_test_image")),
             eval_input_key: Some(String::from("in_eval_image")),
             software_name: test_software.name,
-            base_commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
-            head_commit: String::from("af9cbceb8388e2170881d17f5ca88833c5c37ed6"),
+            base_commit: commit1.clone(),
+            head_commit: commit2.clone(),
             owner: String::from("TestOwner"),
             repo: String::from("TestRepo"),
             issue_number: 4,
@@ -493,10 +477,14 @@ mod tests {
             .with_status(201)
             .create();
 
-        let base_test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let base_eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let head_test_params = json!({"in_test_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
-        let head_eval_params = json!({"in_eval_image":"image_build:TestSoftware|af9cbceb8388e2170881d17f5ca88833c5c37ed6"});
+        let base_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let base_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit1) });
+        let head_test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", &commit2) });
+        let head_eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", &commit2) });
 
         // Make temporary directory for the email
         let email_path = tempfile::Builder::new()
@@ -601,13 +589,13 @@ mod tests {
         assert_run_mapped_to_software_with_commit(
             &conn,
             base_run.run_id,
-            "764a00442ddb412eed331655cfd90e151f580518",
+            &commit1,
             test_software.software_id,
         );
         assert_run_mapped_to_software_with_commit(
             &conn,
             head_run.run_id,
-            "af9cbceb8388e2170881d17f5ca88833c5c37ed6",
+            &commit2,
             test_software.software_id,
         );
 
@@ -619,7 +607,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_process_failure_no_software() {
         let conn = get_test_db_connection();
-        let test_test_runner = create_test_test_runner();
+        let test_test_runner = get_test_test_runner_building_enabled();
         let test_notification_handler = create_test_notification_handler();
         let test_test = insert_test_test_with_subscriptions_with_entities(
             &conn,

--- a/src/manager/github/util.rs
+++ b/src/manager/github/util.rs
@@ -81,23 +81,14 @@ mod tests {
     use crate::models::test::{NewTest, TestData};
     use crate::requests::cromwell_requests::CromwellClient;
     use crate::requests::test_resource_requests::TestResourceClient;
-    use crate::unit_test_util::get_test_db_connection;
+    use crate::unit_test_util::{
+        get_test_db_connection, get_test_remote_github_repo, get_test_test_runner_building_enabled,
+        insert_test_software_with_repo,
+    };
     use actix_web::client::Client;
     use diesel::PgConnection;
     use serde_json::json;
     use uuid::Uuid;
-
-    fn insert_test_software(conn: &PgConnection) -> SoftwareData {
-        let new_software = NewSoftware {
-            name: String::from("TestSoftware"),
-            description: Some(String::from("Kevin made this software for testing")),
-            repository_url: String::from("https://example.com/organization/project"),
-            machine_type: Some(MachineTypeEnum::Standard),
-            created_by: Some(String::from("Kevin@example.com")),
-        };
-
-        SoftwareData::create(conn, new_software).unwrap()
-    }
 
     fn insert_test_pipeline(conn: &PgConnection) -> PipelineData {
         let new_pipeline = NewPipeline {
@@ -180,39 +171,32 @@ mod tests {
         RunGroupData::create(conn).expect("Failed inserting test run_group")
     }
 
-    fn create_test_test_runner() -> TestRunner {
-        let cromwell_client = CromwellClient::new(Client::default(), &mockito::server_url());
-        let test_resource_client = TestResourceClient::new(Client::default(), None);
-        TestRunner::new(
-            cromwell_client,
-            test_resource_client,
-            Some("https://example.com"),
-        )
-    }
-
     #[actix_rt::test]
     async fn test_start_run_from_request() {
         let conn = get_test_db_connection();
         let test_test =
             insert_test_test_with_subscriptions_with_entities(&conn, "test_start_run_from_request");
-        let test_software = insert_test_software(&conn);
+        let (test_repo, commit1, _, _, _) = get_test_remote_github_repo();
+        let test_software = insert_test_software_with_repo(&conn, test_repo.to_str().unwrap());
         let test_run_group = insert_test_run_group(&conn);
-        let test_test_runner = create_test_test_runner();
+        let test_test_runner = get_test_test_runner_building_enabled();
 
         let test_request = GithubRunRequest {
             test_name: test_test.name,
             test_input_key: Some(String::from("in_test_image")),
             eval_input_key: Some(String::from("in_eval_image")),
             software_name: test_software.name,
-            commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
+            commit: commit1.clone(),
             owner: String::from("ExampleOwner"),
             repo: String::from("ExampleRepo"),
             issue_number: 4,
             author: String::from("ExampleKevin"),
         };
 
-        let test_params = json!({"in_test_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
-        let eval_params = json!({"in_eval_image":"image_build:TestSoftware|764a00442ddb412eed331655cfd90e151f580518"});
+        let test_params =
+            json!({ "in_test_image": format!("image_build:TestSoftware|{}", commit1) });
+        let eval_params =
+            json!({ "in_eval_image": format!("image_build:TestSoftware|{}", commit1) });
 
         let cromwell_mock = mockito::mock("POST", "/api/workflows/v1")
             .with_status(201)
@@ -257,10 +241,12 @@ mod tests {
         let software_version_q = SoftwareVersionQuery {
             software_version_id: None,
             software_id: Some(test_software.software_id),
-            commit: Some(String::from("764a00442ddb412eed331655cfd90e151f580518")),
+            commit: Some(commit1),
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,

--- a/src/manager/software_builder.rs
+++ b/src/manager/software_builder.rs
@@ -7,10 +7,12 @@ use crate::models::software_build::{
     NewSoftwareBuild, SoftwareBuildChangeset, SoftwareBuildData, SoftwareBuildQuery,
 };
 use crate::models::software_version::{
-    NewSoftwareVersion, SoftwareVersionData, SoftwareVersionQuery,
+    NewSoftwareVersion, SoftwareVersionChangeset, SoftwareVersionData, SoftwareVersionQuery,
 };
+use crate::models::software_version_tag::{NewSoftwareVersionTag, SoftwareVersionTagData};
 use crate::requests::cromwell_requests::{CromwellClient, CromwellRequestError};
 use crate::util::temp_storage;
+use chrono::NaiveDateTime;
 use diesel::PgConnection;
 use serde_json::{json, Value};
 use std::fmt;
@@ -168,10 +170,12 @@ impl SoftwareBuilder {
 
 /// Attempts to retrieve a software_version record with the specified `software_id` and `commit`,
 /// and creates one if unsuccessful
-pub fn get_or_create_software_version(
+pub fn get_or_create_software_version_with_tags(
     conn: &PgConnection,
     software_id: Uuid,
     commit: &str,
+    tags: &[String],
+    commit_date: &NaiveDateTime,
 ) -> Result<SoftwareVersionData, Error> {
     let software_version_closure = || {
         // Try to find a software version row for this software and commit hash to see if we've ever
@@ -183,23 +187,46 @@ pub fn get_or_create_software_version(
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
         };
         let mut software_version = SoftwareVersionData::find(conn, software_version_query)?;
 
-        // If we found it, return it
+        // If we found it, update its tags and return it
         if !software_version.is_empty() {
-            return Ok(software_version.pop().unwrap());
+            let software_version = software_version.pop().unwrap();
+            return update_existing_software_version(
+                conn,
+                &software_version,
+                commit,
+                tags,
+                commit_date,
+            );
         }
         // If not, create it
         let new_software_version = NewSoftwareVersion {
             commit: String::from(commit),
             software_id,
+            commit_date: commit_date.to_owned(),
         };
+        let software_version: SoftwareVersionData =
+            SoftwareVersionData::create(conn, new_software_version)?;
+        // Create software_version_tag records for any tags
+        if !tags.is_empty() {
+            let mut new_software_version_tags: Vec<NewSoftwareVersionTag> = Vec::new();
+            for tag in tags {
+                new_software_version_tags.push(NewSoftwareVersionTag {
+                    software_version_id: software_version.software_version_id,
+                    tag: tag.to_owned(),
+                });
+            }
+            SoftwareVersionTagData::batch_create(conn, new_software_version_tags)?;
+        }
 
-        Ok(SoftwareVersionData::create(conn, new_software_version)?)
+        Ok(software_version)
     };
 
     // Call in a transaction
@@ -212,6 +239,46 @@ pub fn get_or_create_software_version(
     // tests, we don't specify that this be run in a transaction.
     #[cfg(test)]
     return software_version_closure();
+}
+
+/// Updates the tags for `software_version` using `tags` and also updates `software_version` if its
+/// commit doesn't match `commit` or its commit_date doesn't match `commit_date`.  Returns the
+/// updated software_version record if successful, or an error if it fails
+pub fn update_existing_software_version(
+    conn: &PgConnection,
+    software_version: &SoftwareVersionData,
+    commit: &str,
+    tags: &[String],
+    commit_date: &NaiveDateTime,
+) -> Result<SoftwareVersionData, Error> {
+    // Delete tags so we can replace them with the current ones
+    SoftwareVersionTagData::delete_by_software_version(conn, software_version.software_version_id)?;
+    if !tags.is_empty() {
+        let mut new_software_version_tags: Vec<NewSoftwareVersionTag> = Vec::new();
+        for tag in tags {
+            new_software_version_tags.push(NewSoftwareVersionTag {
+                software_version_id: software_version.software_version_id,
+                tag: tag.to_owned(),
+            });
+        }
+        SoftwareVersionTagData::batch_create(conn, new_software_version_tags)?;
+    }
+    // If the existing software_version has a tag in its commit column, update it to have
+    // the commit and also delete its builds so it'll build again and tag with the commit
+    // hash
+    if software_version.commit != commit || software_version.commit_date != *commit_date {
+        let software_version = SoftwareVersionData::update(
+            &conn,
+            software_version.software_version_id,
+            SoftwareVersionChangeset {
+                commit: Some(String::from(commit)),
+                commit_date: Some(commit_date.to_owned()),
+            },
+        )?;
+        SoftwareBuildData::delete_by_software_version(&conn, software_version.software_version_id)?;
+        return Ok(software_version);
+    }
+    return Ok((*software_version).clone());
 }
 
 /// Attempts to retrieve the most recent software_build record for the specified
@@ -281,16 +348,21 @@ mod tests {
     use crate::config::CustomImageBuildConfig;
     use crate::custom_sql_types::{BuildStatusEnum, MachineTypeEnum};
     use crate::manager::software_builder::{
-        get_or_create_software_build, get_or_create_software_version, SoftwareBuilder,
+        get_or_create_software_build, get_or_create_software_version_with_tags, SoftwareBuilder,
     };
     use crate::models::software::{NewSoftware, SoftwareData};
     use crate::models::software_build::{NewSoftwareBuild, SoftwareBuildData};
     use crate::models::software_version::{NewSoftwareVersion, SoftwareVersionData};
+    use crate::models::software_version_tag::{
+        NewSoftwareVersionTag, SoftwareVersionTagData, SoftwareVersionTagQuery,
+    };
     use crate::requests::cromwell_requests::CromwellClient;
     use crate::unit_test_util::get_test_db_connection;
     use actix_web::client::Client;
+    use chrono::NaiveDateTime;
     use diesel::PgConnection;
     use serde_json::json;
+    use tempfile::TempDir;
 
     fn insert_test_software_version(conn: &PgConnection) -> SoftwareVersionData {
         let new_software = NewSoftware {
@@ -306,6 +378,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         SoftwareVersionData::create(conn, new_software_version)
@@ -338,6 +411,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("2bb75e67f32721abc420294378b3891b97c5a6dc7"),
+            commit_date: "2021-05-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();
@@ -368,6 +442,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("2bb75e67f32721abc420294378b3891b97c5a6dc7"),
+            commit_date: "2021-04-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();
@@ -400,6 +475,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("78875e67f32721abc4202943abc3891b97c5a6dc7"),
+            commit_date: "2021-03-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();
@@ -422,14 +498,59 @@ mod tests {
 
         let test_software_version = insert_test_software_version(&conn);
 
-        let result = get_or_create_software_version(
+        let test_software_version_tags = SoftwareVersionTagData::batch_create(
+            &conn,
+            vec![
+                NewSoftwareVersionTag {
+                    software_version_id: test_software_version.software_version_id,
+                    tag: String::from("tag1"),
+                },
+                NewSoftwareVersionTag {
+                    software_version_id: test_software_version.software_version_id,
+                    tag: String::from("tag2"),
+                },
+            ],
+        )
+        .unwrap();
+
+        let new_tags = vec![String::from("tag1"), String::from("tag3")];
+
+        let result = get_or_create_software_version_with_tags(
             &conn,
             test_software_version.software_id,
             &test_software_version.commit,
+            &new_tags,
+            &"2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         )
         .unwrap();
 
         assert_eq!(test_software_version, result);
+
+        let created_tags = SoftwareVersionTagData::find(
+            &conn,
+            SoftwareVersionTagQuery {
+                software_version_id: Some(result.software_version_id),
+                tag: None,
+                created_before: None,
+                created_after: None,
+                sort: Some(String::from("tag")),
+                limit: None,
+                offset: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(created_tags.len(), 2);
+        assert_eq!(
+            created_tags[0].software_version_id,
+            result.software_version_id
+        );
+        assert_eq!(created_tags[0].tag, "tag1");
+        assert_eq!(
+            created_tags[1].software_version_id,
+            result.software_version_id
+        );
+        assert_eq!(created_tags[1].tag, "tag3");
     }
 
     #[test]
@@ -438,15 +559,45 @@ mod tests {
 
         let test_software = insert_test_software(&conn);
 
-        let result = get_or_create_software_version(
+        let tags = vec![String::from("tag1"), String::from("tag2")];
+
+        let result = get_or_create_software_version_with_tags(
             &conn,
             test_software.software_id,
             "1a4c5eb5fc4921b2642b6ded863894b3745a5dc7",
+            &tags,
+            &"2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         )
         .unwrap();
 
         assert_eq!(result.commit, "1a4c5eb5fc4921b2642b6ded863894b3745a5dc7");
         assert_eq!(result.software_id, test_software.software_id);
+
+        let created_tags = SoftwareVersionTagData::find(
+            &conn,
+            SoftwareVersionTagQuery {
+                software_version_id: Some(result.software_version_id),
+                tag: None,
+                created_before: None,
+                created_after: None,
+                sort: Some(String::from("tag")),
+                limit: None,
+                offset: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(created_tags.len(), 2);
+        assert_eq!(
+            created_tags[0].software_version_id,
+            result.software_version_id
+        );
+        assert_eq!(created_tags[0].tag, "tag1");
+        assert_eq!(
+            created_tags[1].software_version_id,
+            result.software_version_id
+        );
+        assert_eq!(created_tags[1].tag, "tag2");
     }
 
     #[test]
@@ -504,8 +655,12 @@ mod tests {
         let conn = get_test_db_connection();
         let client = Client::default();
         let cromwell_client = CromwellClient::new(client, &mockito::server_url());
-        let config: CustomImageBuildConfig =
-            CustomImageBuildConfig::new(String::from("https://example.com"), None);
+        let temp_repo_dir = TempDir::new().unwrap();
+        let config: CustomImageBuildConfig = CustomImageBuildConfig::new(
+            String::from("https://example.com"),
+            None,
+            temp_repo_dir.path().to_str().unwrap().to_owned(),
+        );
         let test_software_builder: SoftwareBuilder = SoftwareBuilder::new(cromwell_client, &config);
 
         let test_software_build = insert_test_software_build_created(&conn);

--- a/src/manager/status_manager.rs
+++ b/src/manager/status_manager.rs
@@ -5,7 +5,7 @@
 //! Cromwell, and then updating accordingly.  It will also pull result data and add that to the DB
 //! for any tests runs that complete
 
-use crate::config::{Config, StatusManagerConfig};
+use crate::config::{Config, PrivateGithubAccessConfig, StatusManagerConfig};
 use crate::custom_sql_types::{BuildStatusEnum, ReportStatusEnum, ReportableEnum, RunStatusEnum};
 use crate::db::DbPool;
 use crate::manager::notification_handler::NotificationHandler;
@@ -29,6 +29,7 @@ use crate::requests::gcloud_storage::GCloudClient;
 use crate::requests::github_requests::GithubClient;
 use crate::requests::test_resource_requests::TestResourceClient;
 use crate::run_error_logger;
+use crate::util::git_repos::GitRepoManager;
 use actix_web::client::Client;
 use chrono::{NaiveDateTime, Utc};
 use diesel::PgConnection;
@@ -202,12 +203,26 @@ pub async fn init_and_run(
         CromwellClient::new(http_client.clone(), carrot_config.cromwell().address());
     // Create a test runner and software builder
     let test_runner: TestRunner = match carrot_config.custom_image_build() {
-        Some(image_build_config) => TestRunner::new(
+        Some(image_build_config) => {
+            let git_repo_manager = GitRepoManager::new(
+                image_build_config
+                    .private_github_access()
+                    .map(PrivateGithubAccessConfig::to_owned),
+                image_build_config.repo_cache_location().to_owned(),
+            );
+            TestRunner::new(
+                cromwell_client.clone(),
+                test_resource_client.clone(),
+                Some(image_build_config.image_registry_host()),
+                Some(git_repo_manager),
+            )
+        }
+        None => TestRunner::new(
             cromwell_client.clone(),
             test_resource_client.clone(),
-            Some(image_build_config.image_registry_host()),
+            None,
+            None,
         ),
-        None => TestRunner::new(cromwell_client.clone(), test_resource_client.clone(), None),
     };
     // Create a software builder
     let software_builder: Option<SoftwareBuilder> =
@@ -1338,7 +1353,10 @@ mod tests {
     use crate::requests::gcloud_storage::GCloudClient;
     use crate::requests::github_requests::GithubClient;
     use crate::requests::test_resource_requests::TestResourceClient;
-    use crate::unit_test_util::{get_test_db_pool, load_default_config};
+    use crate::unit_test_util::{
+        get_test_db_pool, get_test_test_runner_building_disabled,
+        get_test_test_runner_building_enabled, load_default_config,
+    };
     use actix_web::client::Client;
     use chrono::{NaiveDateTime, Utc};
     use diesel::PgConnection;
@@ -1569,6 +1587,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("2bb75e67f32721abc420294378b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();
@@ -1599,6 +1618,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-05-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         SoftwareVersionData::create(conn, new_software_version)
@@ -1813,12 +1833,8 @@ mod tests {
             CromwellClient::new(http_client.clone(), carrot_config.cromwell().address());
         // Create a test runner and software builder
         let test_runner: TestRunner = match carrot_config.custom_image_build() {
-            Some(image_build_config) => TestRunner::new(
-                cromwell_client.clone(),
-                test_resource_client.clone(),
-                Some(image_build_config.image_registry_host()),
-            ),
-            None => TestRunner::new(cromwell_client.clone(), test_resource_client.clone(), None),
+            Some(_) => get_test_test_runner_building_enabled(),
+            None => get_test_test_runner_building_disabled(),
         };
         // Create a software builder
         let software_builder: Option<SoftwareBuilder> = match carrot_config.custom_image_build() {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,6 +15,7 @@ pub mod run_software_version;
 pub mod software;
 pub mod software_build;
 pub mod software_version;
+pub mod software_version_tag;
 pub mod subscription;
 pub mod template;
 pub mod template_report;

--- a/src/models/result.rs
+++ b/src/models/result.rs
@@ -82,7 +82,7 @@ impl ResultData {
 
     /// Queries the DB for result matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve results matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve results matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved results as ResultData
     /// instances or an error if the query fails for some reason
     pub fn find(

--- a/src/models/run.rs
+++ b/src/models/run.rs
@@ -495,7 +495,7 @@ impl RunWithResultsAndErrorsData {
 
     /// Queries the DB for runs matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve runs matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve runs matching the criteria in `params`
     /// Returns result containing either a vector of the retrieved runs as RunData
     /// instances or an error if the query fails for some reason
     pub fn find(conn: &PgConnection, params: RunQuery) -> Result<Vec<Self>, diesel::result::Error> {
@@ -1177,6 +1177,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
             software_id: new_software.software_id,
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version)
@@ -1185,6 +1186,7 @@ mod tests {
         let new_software_version2 = NewSoftwareVersion {
             commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
             software_id: new_software.software_id,
+            commit_date: "2021-05-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version2 = SoftwareVersionData::create(conn, new_software_version2)

--- a/src/models/run_group_is_from_github.rs
+++ b/src/models/run_group_is_from_github.rs
@@ -111,7 +111,7 @@ impl RunGroupIsFromGithubData {
 
     /// Queries the DB for run_group_is_from_githubs matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve run_group_is_from_githubs matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve run_group_is_from_githubs matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved run_group_is_from_githubs as
     /// RunGroupIsFromGithubData instances or an error if the query fails for some reason
     ///

--- a/src/models/run_is_from_github.rs
+++ b/src/models/run_is_from_github.rs
@@ -71,7 +71,7 @@ impl RunIsFromGithubData {
 
     /// Queries the DB for run_is_from_githubs matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve run_is_from_githubs matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve run_is_from_githubs matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved run_is_from_githubs as
     /// RunIsFromGithubData instances or an error if the query fails for some reason
     ///

--- a/src/models/run_software_version.rs
+++ b/src/models/run_software_version.rs
@@ -253,6 +253,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version)
@@ -320,6 +321,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
             software_id: new_software.software_id,
+            commit_date: "2021-05-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version)
@@ -328,6 +330,7 @@ mod tests {
         let new_software_version2 = NewSoftwareVersion {
             commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
             software_id: new_software.software_id,
+            commit_date: "2021-04-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version2 = SoftwareVersionData::create(conn, new_software_version2)

--- a/src/models/software_build.rs
+++ b/src/models/software_build.rs
@@ -133,7 +133,7 @@ impl SoftwareBuildData {
 
     /// Queries the DB for software_builds matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve software_builds matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve software_builds matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved software_builds as SoftwareBuildData
     /// instances or an error if the query fails for some reason
     pub fn find(
@@ -272,6 +272,19 @@ impl SoftwareBuildData {
             .set(params)
             .get_result(conn)
     }
+
+    /// Deletes software_build rows in the DB for the software_version specified by `id`
+    ///
+    /// Deletes the software_build rows in the DB using `conn` mapped to the software_version
+    /// specified by `id`
+    /// Returns a result containing either the number of rows deleted or an error if the delete
+    /// fails for some reason
+    pub fn delete_by_software_version(
+        conn: &PgConnection,
+        id: Uuid,
+    ) -> Result<usize, diesel::result::Error> {
+        diesel::delete(software_build.filter(software_version_id.eq(id))).execute(conn)
+    }
 }
 
 #[cfg(test)]
@@ -304,6 +317,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();
@@ -359,6 +373,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         software_versions.push(
@@ -369,6 +384,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
             software_id: new_software.software_id,
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         software_versions.push(
@@ -858,5 +874,28 @@ mod tests {
             Some(String::from("example.com/kevin"))
         );
         assert_eq!(updated_software_build.status, BuildStatusEnum::Succeeded);
+    }
+
+    #[test]
+    fn delete_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_build = insert_test_software_build(&conn);
+
+        let delete_result = SoftwareBuildData::delete_by_software_version(
+            &conn,
+            test_software_build.software_version_id,
+        )
+        .unwrap();
+
+        assert_eq!(delete_result, 1);
+
+        let deleted_software_build =
+            SoftwareBuildData::find_by_id(&conn, test_software_build.software_build_id);
+
+        assert!(matches!(
+            deleted_software_build,
+            Err(diesel::result::Error::NotFound)
+        ));
     }
 }

--- a/src/models/software_version.rs
+++ b/src/models/software_version.rs
@@ -5,9 +5,12 @@
 
 use crate::custom_sql_types::MachineTypeEnum;
 use crate::models::software::SoftwareData;
+use crate::models::sql_functions;
 use crate::schema::software;
 use crate::schema::software_version;
 use crate::schema::software_version::dsl::*;
+use crate::schema::software_version_tag;
+use crate::schema::software_version_with_tags;
 use crate::util;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -17,14 +20,28 @@ use uuid::Uuid;
 /// Mapping to a software_version as it exists in the SOFTWARE_VERSION table in the database.
 ///
 /// An instance of this struct will be returned by any queries for software_versions.
-#[derive(Queryable, Deserialize, Serialize, PartialEq, Debug)]
+#[derive(Queryable, Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct SoftwareVersionData {
     pub software_version_id: Uuid,
     pub software_id: Uuid,
     pub commit: String,
+    pub commit_date: NaiveDateTime,
     pub created_at: NaiveDateTime,
 }
 
+/// Mapping to a software_version as viewed through the SOFTWARE_VERSION_WITH_TAGS view, which
+/// assembles data from the SOFTWARE_VERSION and SOFTWARE_VERSION_TAG tables
+///
+/// An instance of this struct will be returned by any queries for software_versions with tags.
+#[derive(Queryable, Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct SoftwareVersionWithTagsData {
+    pub software_version_id: Uuid,
+    pub software_id: Uuid,
+    pub commit: String,
+    pub commit_date: NaiveDateTime,
+    pub tags: Vec<String>,
+    pub created_at: NaiveDateTime,
+}
 /// Represents all possible parameters for a query of the SOFTWARE_VERSION table
 ///
 /// All values are optional, so any combination can be used during a query.  Limit and offset are
@@ -38,6 +55,8 @@ pub struct SoftwareVersionQuery {
     pub software_name: Option<String>,
     pub created_before: Option<NaiveDateTime>,
     pub created_after: Option<NaiveDateTime>,
+    pub committed_before: Option<NaiveDateTime>,
+    pub committed_after: Option<NaiveDateTime>,
     pub sort: Option<String>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
@@ -45,13 +64,27 @@ pub struct SoftwareVersionQuery {
 
 /// A new software_version to be inserted into the DB
 ///
-/// commit and software_id are both required fields; software_version_id and created_at are
+/// commit, commit_date, and software_id are required fields; software_version_id and created_at are
 /// populated automatically by the DB
 #[derive(Deserialize, Serialize, Insertable)]
 #[table_name = "software_version"]
 pub struct NewSoftwareVersion {
     pub commit: String,
     pub software_id: Uuid,
+    pub commit_date: NaiveDateTime,
+}
+
+/// Represents fields to change when updating a software_version
+///
+/// Only commit and commit_date can be modified after the software_version has been created, and
+/// this is really only intended to be used to change commits that are tags (from before the tag
+/// storage change) to the actual commits and to update commit dates to their actual date from the
+/// default value that was inserted for records that existed before the commit_date was added
+#[derive(Deserialize, Serialize, AsChangeset, Debug)]
+#[table_name = "software_version"]
+pub struct SoftwareVersionChangeset {
+    pub commit: Option<String>,
+    pub commit_date: Option<NaiveDateTime>,
 }
 
 impl SoftwareVersionData {
@@ -90,9 +123,31 @@ impl SoftwareVersionData {
             .first::<(String, String, MachineTypeEnum, String)>(conn)
     }
 
+    /// Queries the DB for the commit belonging to the software_version record for the software with
+    /// name equal to `software_name` and either commit equal to `commit_or_tag` or a mapped
+    /// software_version_tag record with tag equal to `commit_or_tag`
+    pub fn find_commit_by_name_and_commit_or_tag(
+        conn: &PgConnection,
+        software_name: &str,
+        commit_or_tag: &str,
+    ) -> Result<String, diesel::result::Error> {
+        software_version
+            .left_outer_join(software_version_tag::table)
+            .inner_join(software::table)
+            .filter(sql_functions::lower(software::name).eq(software_name.to_lowercase()))
+            .filter(
+                commit
+                    .eq(commit_or_tag)
+                    .or(software_version_tag::tag.eq(commit_or_tag)),
+            )
+            .limit(1)
+            .select(commit)
+            .first::<String>(conn)
+    }
+
     /// Queries the DB for software_versions matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve software_versions matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve software_versions matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved software_versions as SoftwareVersionData
     /// instances or an error if the query fails for some reason
     pub fn find(
@@ -136,6 +191,12 @@ impl SoftwareVersionData {
         if let Some(param) = params.created_after {
             query = query.filter(created_at.gt(param));
         }
+        if let Some(param) = params.committed_before {
+            query = query.filter(commit_date.lt(param));
+        }
+        if let Some(param) = params.committed_after {
+            query = query.filter(commit_date.gt(param));
+        }
 
         // If there is a sort param, parse it and add to the order by clause accordingly
         if let Some(sort) = params.sort {
@@ -161,6 +222,13 @@ impl SoftwareVersionData {
                             query = query.then_order_by(commit.asc());
                         } else {
                             query = query.then_order_by(commit.desc());
+                        }
+                    }
+                    "commit_date" => {
+                        if sort_clause.ascending {
+                            query = query.then_order_by(commit_date.asc());
+                        } else {
+                            query = query.then_order_by(commit_date.desc());
                         }
                     }
                     "created_at" => {
@@ -200,14 +268,176 @@ impl SoftwareVersionData {
             .values(&params)
             .get_result(conn)
     }
+
+    /// Updates a specified software_version in the DB
+    ///
+    /// Updates the software_version row in the DB using `conn` specified by `id` with the values in
+    /// `params`
+    /// Returns a result containing either the newly updated software_version or an error if the
+    /// update fails for some reason
+    ///
+    /// NOTE: This is only meant to be used to correct when a software_version's commit is actually
+    /// a tag from back before tags were stored separately
+    pub fn update(
+        conn: &PgConnection,
+        id: Uuid,
+        params: SoftwareVersionChangeset,
+    ) -> Result<Self, diesel::result::Error> {
+        diesel::update(software_version.filter(software_version_id.eq(id)))
+            .set(params)
+            .get_result(conn)
+    }
+}
+
+impl SoftwareVersionWithTagsData {
+    /// Queries the DB for a software_version with tags with the specified id
+    ///
+    /// Queries the DB using `conn` to retrieve the first row with a software_version_id value of
+    /// `id` in the SOFTWARE_VERSION_WITH_TAGS view
+    /// Returns a result containing either the retrieved software_version as a
+    /// SoftwareVersionWithTagsData instance or an error if the query fails for some reason or if no
+    /// software_version is found matching the criteria
+    pub fn find_by_id(conn: &PgConnection, id: Uuid) -> Result<Self, diesel::result::Error> {
+        software_version_with_tags::table
+            .filter(software_version_with_tags::dsl::software_version_id.eq(id))
+            .first::<Self>(conn)
+    }
+
+    /// Queries the DB for software_version_with_tags matching the specified query criteria
+    ///
+    /// Queries the DB using `conn` to retrieve software_version_with_tags matching the criteria in
+    /// `params`
+    /// Returns a result containing either a vector of the retrieved software_version_with_tags as
+    /// SoftwareVersionWithTagsData instances or an error if the query fails for some reason
+    pub fn find(
+        conn: &PgConnection,
+        params: SoftwareVersionQuery,
+    ) -> Result<Vec<Self>, diesel::result::Error> {
+        // Put the query into a box (pointer) so it can be built dynamically
+        let mut query = software_version_with_tags::dsl::software_version_with_tags.into_boxed();
+
+        // If there's a software_name param, retrieve the software_id from the SOFTWARE table and
+        // filter by that
+        if let Some(param) = params.software_name {
+            let softwares = software::dsl::software
+                .filter(software::dsl::name.eq(param))
+                .first::<SoftwareData>(conn);
+            match softwares {
+                Ok(softwares_res) => {
+                    query = query.filter(
+                        software_version_with_tags::dsl::software_id.eq(softwares_res.software_id),
+                    );
+                }
+                Err(diesel::NotFound) => {
+                    return Ok(Vec::new());
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        // Add filters for each of the other params if they have values
+        if let Some(param) = params.software_version_id {
+            query = query.filter(software_version_with_tags::dsl::software_version_id.eq(param));
+        }
+        if let Some(param) = params.software_id {
+            query = query.filter(software_version_with_tags::dsl::software_id.eq(param));
+        }
+        if let Some(param) = params.commit {
+            query = query.filter(software_version_with_tags::dsl::commit.eq(param));
+        }
+        if let Some(param) = params.created_before {
+            query = query.filter(software_version_with_tags::dsl::created_at.lt(param));
+        }
+        if let Some(param) = params.created_after {
+            query = query.filter(software_version_with_tags::dsl::created_at.gt(param));
+        }
+        if let Some(param) = params.committed_before {
+            query = query.filter(software_version_with_tags::dsl::commit_date.lt(param));
+        }
+        if let Some(param) = params.committed_after {
+            query = query.filter(software_version_with_tags::dsl::commit_date.gt(param));
+        }
+
+        // If there is a sort param, parse it and add to the order by clause accordingly
+        if let Some(sort) = params.sort {
+            let sort = util::sort_string::parse(&sort);
+            for sort_clause in sort {
+                match &sort_clause.key[..] {
+                    "software_version_id" => {
+                        if sort_clause.ascending {
+                            query = query.then_order_by(
+                                software_version_with_tags::dsl::software_version_id.asc(),
+                            );
+                        } else {
+                            query = query.then_order_by(
+                                software_version_with_tags::dsl::software_version_id.desc(),
+                            );
+                        }
+                    }
+                    "software_id" => {
+                        if sort_clause.ascending {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::software_id.asc());
+                        } else {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::software_id.desc());
+                        }
+                    }
+                    "commit" => {
+                        if sort_clause.ascending {
+                            query =
+                                query.then_order_by(software_version_with_tags::dsl::commit.asc());
+                        } else {
+                            query =
+                                query.then_order_by(software_version_with_tags::dsl::commit.desc());
+                        }
+                    }
+                    "commit_date" => {
+                        if sort_clause.ascending {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::commit_date.asc());
+                        } else {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::commit_date.desc());
+                        }
+                    }
+                    "created_at" => {
+                        if sort_clause.ascending {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::created_at.asc());
+                        } else {
+                            query = query
+                                .then_order_by(software_version_with_tags::dsl::created_at.desc());
+                        }
+                    }
+                    // Don't add to the order by clause if the sort key isn't recognized
+                    &_ => {}
+                }
+            }
+        }
+
+        if let Some(param) = params.limit {
+            query = query.limit(param);
+        }
+        if let Some(param) = params.offset {
+            query = query.offset(param);
+        }
+
+        // Perform the query
+        query.load::<Self>(conn)
+    }
 }
 
 #[cfg(test)]
 mod tests {
 
     use super::*;
-    use crate::models::software::NewSoftware;
     use crate::models::software::SoftwareData;
+    use crate::models::software::{NewSoftware, SoftwareQuery};
+    use crate::models::software_version_tag::{
+        NewSoftwareVersionTag, SoftwareVersionTagData, SoftwareVersionTagQuery,
+    };
     use crate::unit_test_util::*;
     use uuid::Uuid;
 
@@ -225,10 +455,45 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2022-01-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         SoftwareVersionData::create(conn, new_software_version)
             .expect("Failed inserting test software_version")
+    }
+
+    fn assert_software_version_with_tags_equal_to_software_version_and_tags(
+        test_software_version_with_tags: &SoftwareVersionWithTagsData,
+        test_software_version: &SoftwareVersionData,
+        test_software_version_tags: &Vec<SoftwareVersionTagData>,
+    ) {
+        assert_eq!(
+            test_software_version_with_tags.software_version_id,
+            test_software_version.software_version_id
+        );
+        assert_eq!(
+            test_software_version_with_tags.software_id,
+            test_software_version.software_id
+        );
+        assert_eq!(
+            test_software_version_with_tags.commit,
+            test_software_version.commit
+        );
+        assert_eq!(
+            test_software_version_with_tags.commit_date,
+            test_software_version.commit_date
+        );
+        assert_eq!(
+            test_software_version_with_tags.created_at,
+            test_software_version.created_at
+        );
+        assert_eq!(
+            test_software_version_with_tags.tags.len(),
+            test_software_version_tags.len()
+        );
+        for tag in test_software_version_tags {
+            assert!(test_software_version_with_tags.tags.contains(&tag.tag));
+        }
     }
 
     fn insert_software_versions_with_software(
@@ -244,6 +509,26 @@ mod tests {
         let new_software_versions = insert_test_software_versions_with_software_id(conn, ids);
 
         (new_softwares, new_software_versions)
+    }
+
+    fn insert_software_version_tags_for_software_version(
+        conn: &PgConnection,
+        version_id: Uuid,
+    ) -> Vec<SoftwareVersionTagData> {
+        let mut software_version_tags = Vec::new();
+        let new_software_version_tag = NewSoftwareVersionTag {
+            software_version_id: version_id,
+            tag: String::from("tag1"),
+        };
+        software_version_tags
+            .push(SoftwareVersionTagData::create(conn, new_software_version_tag).unwrap());
+        let new_software_version_tag = NewSoftwareVersionTag {
+            software_version_id: version_id,
+            tag: String::from("tag2"),
+        };
+        software_version_tags
+            .push(SoftwareVersionTagData::create(conn, new_software_version_tag).unwrap());
+        software_version_tags
     }
 
     fn insert_test_softwares(conn: &PgConnection) -> Vec<SoftwareData> {
@@ -283,8 +568,9 @@ mod tests {
         let mut software_versions = Vec::new();
 
         let new_software_version = NewSoftwareVersion {
-            commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit: String::from("93ac5e85f34921b2642beded8b3891b97c5a6dc7"),
             software_id: ids[0],
+            commit_date: "2022-01-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         software_versions.push(
@@ -295,6 +581,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
             software_id: ids[1].clone(),
+            commit_date: "2021-01-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         software_versions.push(
@@ -303,8 +590,9 @@ mod tests {
         );
 
         let new_software_version = NewSoftwareVersion {
-            commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
+            commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466"),
             software_id: ids[1],
+            commit_date: "2020-01-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         software_versions.push(
@@ -364,6 +652,59 @@ mod tests {
     }
 
     #[test]
+    fn find_commit_by_name_and_commit_or_tag_success_commit() {
+        let conn = get_test_db_connection();
+
+        let (softwares, software_versions) = insert_software_versions_with_software(&conn);
+
+        let result = SoftwareVersionData::find_commit_by_name_and_commit_or_tag(
+            &conn,
+            &softwares[0].name,
+            &software_versions[0].commit,
+        )
+        .unwrap();
+
+        assert_eq!(result, software_versions[0].commit);
+    }
+
+    #[test]
+    fn find_commit_by_name_and_commit_or_tag_success_tag() {
+        let conn = get_test_db_connection();
+
+        let (softwares, software_versions) = insert_software_versions_with_software(&conn);
+
+        let software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            software_versions[1].software_version_id,
+        );
+
+        let result = SoftwareVersionData::find_commit_by_name_and_commit_or_tag(
+            &conn,
+            &softwares[1].name,
+            &software_version_tags[0].tag,
+        )
+        .unwrap();
+
+        assert_eq!(result, software_versions[1].commit);
+    }
+
+    #[test]
+    fn find_commit_by_name_and_commit_or_tag_failure_not_found() {
+        let conn = get_test_db_connection();
+
+        let (softwares, software_versions) = insert_software_versions_with_software(&conn);
+
+        let result = SoftwareVersionData::find_commit_by_name_and_commit_or_tag(
+            &conn,
+            &softwares[0].name,
+            "nonexistent_tag",
+        )
+        .unwrap_err();
+
+        assert_eq!(result, diesel::result::Error::NotFound);
+    }
+
+    #[test]
     fn find_with_software_version_id() {
         let conn = get_test_db_connection();
 
@@ -377,6 +718,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -403,6 +746,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -428,6 +773,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -454,6 +801,8 @@ mod tests {
             software_name: Some(test_software[0].name.clone()),
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -479,6 +828,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: Some(String::from("commit")),
             limit: Some(2),
             offset: None,
@@ -498,6 +849,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: Some(String::from("commit")),
             limit: Some(2),
             offset: Some(2),
@@ -523,6 +876,8 @@ mod tests {
             software_name: None,
             created_before: None,
             created_after: Some("2099-01-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -540,6 +895,8 @@ mod tests {
             software_name: None,
             created_before: Some("2099-01-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
             created_after: None,
+            committed_before: None,
+            committed_after: None,
             sort: None,
             limit: None,
             offset: None,
@@ -552,6 +909,51 @@ mod tests {
     }
 
     #[test]
+    fn find_with_committed_before_and_created_after() {
+        let conn = get_test_db_connection();
+
+        insert_software_versions_with_software(&conn);
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: None,
+            software_id: None,
+            commit: None,
+            software_name: None,
+            created_before: None,
+            created_after: None,
+            committed_before: None,
+            committed_after: Some("2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_versions =
+            SoftwareVersionData::find(&conn, test_query).expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 1);
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: None,
+            software_id: None,
+            commit: None,
+            software_name: None,
+            created_before: None,
+            created_after: None,
+            committed_before: Some("2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+            committed_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_versions =
+            SoftwareVersionData::find(&conn, test_query).expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 2);
+    }
+
+    #[test]
     fn create_success() {
         let conn = get_test_db_connection();
 
@@ -560,6 +962,212 @@ mod tests {
         assert_eq!(
             test_software_version.commit,
             "9aac5e85f34921b2642beded8b3891b97c5a6dc7"
+        );
+    }
+
+    #[test]
+    fn update_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_version = insert_test_software_version(&conn);
+
+        let changes = SoftwareVersionChangeset {
+            commit: Some(String::from("100ca53f-ad64-4b30-8944-89958d00e69b")),
+            commit_date: Some("2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+        };
+
+        let updated_software_version =
+            SoftwareVersionData::update(&conn, test_software_version.software_version_id, changes)
+                .expect("Failed to update software_version");
+
+        assert_eq!(
+            updated_software_version.commit,
+            String::from("100ca53f-ad64-4b30-8944-89958d00e69b")
+        );
+
+        assert_eq!(
+            updated_software_version.commit_date,
+            "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap()
+        );
+    }
+
+    #[test]
+    fn find_by_id_exists_with_tags() {
+        let conn = get_test_db_connection();
+
+        let test_software_version = insert_test_software_version(&conn);
+        let test_software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            test_software_version.software_version_id,
+        );
+
+        let found_software_version = SoftwareVersionWithTagsData::find_by_id(
+            &conn,
+            test_software_version.software_version_id,
+        )
+        .expect("Failed to retrieve test software_version by id.");
+
+        assert_software_version_with_tags_equal_to_software_version_and_tags(
+            &found_software_version,
+            &test_software_version,
+            &test_software_version_tags,
+        );
+    }
+
+    #[test]
+    fn find_by_id_not_exists_with_tags() {
+        let conn = get_test_db_connection();
+
+        let nonexistent_software_version =
+            SoftwareVersionWithTagsData::find_by_id(&conn, Uuid::new_v4());
+
+        assert!(matches!(
+            nonexistent_software_version,
+            Err(diesel::result::Error::NotFound)
+        ));
+    }
+
+    #[test]
+    fn find_with_software_version_id_with_tags() {
+        let conn = get_test_db_connection();
+
+        insert_software_versions_with_software(&conn);
+        let test_software_version = insert_test_software_version(&conn);
+        let test_software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            test_software_version.software_version_id,
+        );
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: Some(test_software_version.software_version_id),
+            software_id: None,
+            commit: None,
+            software_name: None,
+            created_before: None,
+            created_after: None,
+            committed_before: None,
+            committed_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let mut found_software_versions = SoftwareVersionWithTagsData::find(&conn, test_query)
+            .expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 1);
+        assert_software_version_with_tags_equal_to_software_version_and_tags(
+            found_software_versions.get(0).unwrap(),
+            &test_software_version,
+            &test_software_version_tags,
+        );
+    }
+
+    #[test]
+    fn find_with_software_id_with_tags() {
+        let conn = get_test_db_connection();
+
+        insert_software_versions_with_software(&conn);
+        let test_software_version = insert_test_software_version(&conn);
+        let test_software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            test_software_version.software_version_id,
+        );
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: None,
+            software_id: Some(test_software_version.software_id),
+            commit: None,
+            software_name: None,
+            created_before: None,
+            created_after: None,
+            committed_before: None,
+            committed_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let mut found_software_versions = SoftwareVersionWithTagsData::find(&conn, test_query)
+            .expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 1);
+        assert_software_version_with_tags_equal_to_software_version_and_tags(
+            found_software_versions.get(0).unwrap(),
+            &test_software_version,
+            &test_software_version_tags,
+        );
+    }
+
+    #[test]
+    fn find_with_commit_with_tags() {
+        let conn = get_test_db_connection();
+
+        let (_, test_software_versions) = insert_software_versions_with_software(&conn);
+        let test_software_version = insert_test_software_version(&conn);
+        let test_software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            test_software_version.software_version_id,
+        );
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: None,
+            software_id: None,
+            commit: Some(test_software_version.commit.clone()),
+            software_name: None,
+            created_before: None,
+            created_after: None,
+            committed_before: None,
+            committed_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let mut found_software_versions = SoftwareVersionWithTagsData::find(&conn, test_query)
+            .expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 1);
+        assert_software_version_with_tags_equal_to_software_version_and_tags(
+            found_software_versions.get(0).unwrap(),
+            &test_software_version,
+            &test_software_version_tags,
+        );
+    }
+
+    #[test]
+    fn find_with_software_name_with_tags() {
+        let conn = get_test_db_connection();
+
+        let (test_software, test_software_versions) = insert_software_versions_with_software(&conn);
+        let test_software_version = insert_test_software_version(&conn);
+        let test_software_version_tags = insert_software_version_tags_for_software_version(
+            &conn,
+            test_software_version.software_version_id,
+        );
+
+        let test_query = SoftwareVersionQuery {
+            software_version_id: None,
+            software_id: None,
+            commit: None,
+            software_name: Some(test_software[0].name.clone()),
+            created_before: None,
+            created_after: None,
+            committed_before: None,
+            committed_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let mut found_software_versions = SoftwareVersionWithTagsData::find(&conn, test_query)
+            .expect("Failed to find software_versions");
+
+        assert_eq!(found_software_versions.len(), 1);
+        assert_software_version_with_tags_equal_to_software_version_and_tags(
+            found_software_versions.get(0).unwrap(),
+            test_software_versions.get(0).unwrap(),
+            &Vec::new(),
         );
     }
 }

--- a/src/models/software_version_tag.rs
+++ b/src/models/software_version_tag.rs
@@ -1,0 +1,593 @@
+//! Contains structs and functions for doing operations on run results.
+//!
+//! A software_version_tag represents a specific result of a specific run of a test.  Represented in the
+//! database by the SOFTWARE_VERSION_TAG table.
+
+use crate::schema::software_version_tag;
+use crate::schema::software_version_tag::dsl::*;
+use crate::util;
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Mapping to a run result as it exists in the SOFTWARE_VERSION_TAG table in the database.
+///
+/// An instance of this struct will be returned by any queries for run results.
+#[derive(Queryable, Deserialize, Serialize, PartialEq, Debug)]
+pub struct SoftwareVersionTagData {
+    pub software_version_id: Uuid,
+    pub tag: String,
+    pub created_at: NaiveDateTime,
+}
+
+/// Represents all possible parameters for a query of the SOFTWARE_VERSION_TAG table
+///
+/// All values are optional, so any combination can be used during a query.  Limit and offset are
+/// used for pagination.  Sort expects a comma-separated list of sort keys, optionally enclosed
+/// with either asc() or desc().  For example: asc(created_at),desc(software_version_id),tag
+#[derive(Deserialize, Debug)]
+pub struct SoftwareVersionTagQuery {
+    pub software_version_id: Option<Uuid>,
+    pub tag: Option<String>,
+    pub created_before: Option<NaiveDateTime>,
+    pub created_after: Option<NaiveDateTime>,
+    pub sort: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// A new run result to be inserted into the DB
+///
+/// software_version_id, and tag are required fields
+/// created_at is populated automatically by the DB
+#[derive(Deserialize, Insertable)]
+#[table_name = "software_version_tag"]
+pub struct NewSoftwareVersionTag {
+    pub software_version_id: Uuid,
+    pub tag: String,
+}
+
+impl SoftwareVersionTagData {
+    /// Queries the DB for a software_version_tag for the specified ids
+    ///
+    /// Queries the DB using `conn` to retrieve the first row with a software_version_id matching
+    /// `query_software_version_id` and a tag matching `query_tag`
+    /// Returns a result containing either the retrieved software_version_tag mapping as a
+    /// SoftwareVersionTagData instance or an error if the query fails for some reason or if no
+    /// mapping is found matching the criteria
+    #[allow(dead_code)]
+    pub fn find_by_software_version_and_tag(
+        conn: &PgConnection,
+        query_software_version_id: Uuid,
+        query_tag: &str,
+    ) -> Result<Self, diesel::result::Error> {
+        software_version_tag
+            .filter(tag.eq(query_tag))
+            .filter(software_version_id.eq(query_software_version_id))
+            .first::<Self>(conn)
+    }
+
+    /// Queries the DB for software_version_tag records matching the specified query criteria
+    ///
+    /// Queries the DB using `conn` to retrieve software_version_tag records matching the criteria in
+    /// `params`
+    /// Returns a result containing either a vector of the retrieved software_version_tag records as
+    /// SoftwareVersionTagData instances or an error if the query fails for some reason
+    #[allow(dead_code)]
+    pub fn find(
+        conn: &PgConnection,
+        params: SoftwareVersionTagQuery,
+    ) -> Result<Vec<Self>, diesel::result::Error> {
+        // Put the query into a box (pointer) so it can be built dynamically
+        let mut query = software_version_tag.into_boxed();
+
+        // Add filters for each of the params if they have tags
+        if let Some(param) = params.software_version_id {
+            query = query.filter(software_version_id.eq(param));
+        }
+        if let Some(param) = params.tag {
+            query = query.filter(tag.eq(param));
+        }
+        if let Some(param) = params.created_before {
+            query = query.filter(created_at.lt(param));
+        }
+        if let Some(param) = params.created_after {
+            query = query.filter(created_at.gt(param));
+        }
+
+        // If there is a sort param, parse it and add to the order by clause accordingly
+        if let Some(sort) = params.sort {
+            let sort = util::sort_string::parse(&sort);
+            for sort_clause in sort {
+                match &sort_clause.key[..] {
+                    "software_version_id" => {
+                        if sort_clause.ascending {
+                            query = query.then_order_by(software_version_id.asc());
+                        } else {
+                            query = query.then_order_by(software_version_id.desc());
+                        }
+                    }
+                    "tag" => {
+                        if sort_clause.ascending {
+                            query = query.then_order_by(tag.asc());
+                        } else {
+                            query = query.then_order_by(tag.desc());
+                        }
+                    }
+                    "created_at" => {
+                        if sort_clause.ascending {
+                            query = query.then_order_by(created_at.asc());
+                        } else {
+                            query = query.then_order_by(created_at.desc());
+                        }
+                    }
+                    // Don't add to the order by clause of the sort key isn't recognized
+                    &_ => {}
+                }
+            }
+        }
+
+        if let Some(param) = params.limit {
+            query = query.limit(param);
+        }
+        if let Some(param) = params.offset {
+            query = query.offset(param);
+        }
+
+        // Perform the query
+        query.load::<Self>(conn)
+    }
+
+    /// Inserts a new software_version_tag mapping into the DB
+    ///
+    /// Creates a new software_version_tag row in the DB using `conn` with the tags specified in
+    /// `params`
+    /// Returns a result containing either the new software_version_tag record that was created or an
+    /// error if the insert fails for some reason
+    #[allow(dead_code)]
+    pub fn create(
+        conn: &PgConnection,
+        params: NewSoftwareVersionTag,
+    ) -> Result<Self, diesel::result::Error> {
+        diesel::insert_into(software_version_tag)
+            .values(&params)
+            .get_result(conn)
+    }
+
+    /// Inserts multiple new software_version_tag mappings into the DB
+    ///
+    /// Creates a new software_version_tag row in the DB using `conn` for each insert record specified in
+    /// `params`
+    /// Returns a result containing either the new software_version_tag records that were created or an
+    /// error if the insert fails for some reason
+    pub fn batch_create(
+        conn: &PgConnection,
+        params: Vec<NewSoftwareVersionTag>,
+    ) -> Result<Vec<Self>, diesel::result::Error> {
+        diesel::insert_into(software_version_tag)
+            .values(&params)
+            .get_results(conn)
+    }
+
+    /// Deletes software_version_tags from the DB that are mapped to the software_version specified
+    /// by `id`
+    ///
+    /// Returns either the number of software_version_tags deleted, or an error if something goes
+    /// wrong during the delete
+    #[allow(dead_code)]
+    pub fn delete_by_software_version(
+        conn: &PgConnection,
+        id: Uuid,
+    ) -> Result<usize, diesel::result::Error> {
+        diesel::delete(software_version_tag)
+            .filter(software_version_id.eq(id))
+            .execute(conn)
+    }
+
+    /// Deletes software_version_tags from the DB that are mapped to the software_version specified
+    /// by `query_software_version_id` and with the tag `query_tag`
+    ///
+    /// Returns either the number of software_version_tags deleted, or an error if something goes
+    /// wrong during the delete
+    #[allow(dead_code)]
+    pub fn delete_by_software_version_and_tag(
+        conn: &PgConnection,
+        query_software_version_id: Uuid,
+        query_tag: &str,
+    ) -> Result<usize, diesel::result::Error> {
+        diesel::delete(software_version_tag)
+            .filter(software_version_id.eq(query_software_version_id))
+            .filter(tag.eq(query_tag))
+            .execute(conn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::custom_sql_types::{MachineTypeEnum, ResultTypeEnum, RunStatusEnum};
+    use crate::models::pipeline::{NewPipeline, PipelineData};
+    use crate::models::result::{NewResult, ResultData};
+    use crate::models::run::{NewRun, RunData};
+    use crate::models::software::{NewSoftware, SoftwareData};
+    use crate::models::software_version::{NewSoftwareVersion, SoftwareVersionData};
+    use crate::models::template::{NewTemplate, TemplateData};
+    use crate::models::test::{NewTest, TestData};
+    use crate::unit_test_util::*;
+    use chrono::Utc;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    fn insert_test_software_version_tag(conn: &PgConnection) -> SoftwareVersionTagData {
+        let new_software = NewSoftware {
+            name: String::from("Kevin's Software"),
+            description: Some(String::from("Kevin made this software for testing")),
+            repository_url: String::from("https://example.com/organization/project"),
+            machine_type: Some(MachineTypeEnum::Standard),
+            created_by: Some(String::from("Kevin@example.com")),
+        };
+
+        let new_software = SoftwareData::create(conn, new_software).unwrap();
+
+        let new_software_version = NewSoftwareVersion {
+            software_id: new_software.software_id,
+            commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-04-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
+        };
+
+        let new_software_version = SoftwareVersionData::create(conn, new_software_version)
+            .expect("Failed inserting test software_version");
+
+        let new_software_version_tag = NewSoftwareVersionTag {
+            tag: String::from("test"),
+            software_version_id: new_software_version.software_version_id,
+        };
+
+        SoftwareVersionTagData::create(conn, new_software_version_tag)
+            .expect("Failed inserting test software_version_tag")
+    }
+
+    fn insert_test_software_version_tags(conn: &PgConnection) -> Vec<SoftwareVersionTagData> {
+        let new_software = NewSoftware {
+            name: String::from("Kevin's Software2"),
+            description: Some(String::from("Kevin made this software for testing also")),
+            repository_url: String::from("https://example.com/organization/project2"),
+            machine_type: Some(MachineTypeEnum::Standard),
+            created_by: Some(String::from("Kevin@example.com")),
+        };
+
+        let new_software =
+            SoftwareData::create(conn, new_software).expect("Failed to insert software");
+
+        let new_software_version = NewSoftwareVersion {
+            commit: String::from("764a00442ddb412eed331655cfd90e151f580518"),
+            software_id: new_software.software_id,
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
+        };
+
+        let new_software_version = SoftwareVersionData::create(conn, new_software_version)
+            .expect("Failed inserting test software_version");
+
+        let new_software_version2 = NewSoftwareVersion {
+            commit: String::from("c9d1a4eb7d1c49428b03bee19a72401b02cec466 "),
+            software_id: new_software.software_id,
+            commit_date: "2021-05-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
+        };
+
+        let new_software_version2 = SoftwareVersionData::create(conn, new_software_version2)
+            .expect("Failed inserting test software_version");
+
+        let mut new_software_version_tags = Vec::new();
+
+        new_software_version_tags.push(NewSoftwareVersionTag {
+            tag: String::from("test1"),
+            software_version_id: new_software_version.software_version_id,
+        });
+
+        new_software_version_tags.push(NewSoftwareVersionTag {
+            tag: String::from("test2"),
+            software_version_id: new_software_version.software_version_id,
+        });
+
+        new_software_version_tags.push(NewSoftwareVersionTag {
+            tag: String::from("test3"),
+            software_version_id: new_software_version2.software_version_id,
+        });
+
+        SoftwareVersionTagData::batch_create(conn, new_software_version_tags).unwrap()
+    }
+
+    #[test]
+    fn find_by_run_and_result_exists() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tag = insert_test_software_version_tag(&conn);
+
+        let found_software_version_tag = SoftwareVersionTagData::find_by_software_version_and_tag(
+            &conn,
+            test_software_version_tag.software_version_id,
+            &test_software_version_tag.tag,
+        )
+        .expect("Failed to retrieve test software_version_tag by id.");
+
+        assert_eq!(found_software_version_tag, test_software_version_tag);
+    }
+
+    #[test]
+    fn find_by_id_not_exists() {
+        let conn = get_test_db_connection();
+
+        let nonexistent_software_version_tag =
+            SoftwareVersionTagData::find_by_software_version_and_tag(&conn, Uuid::new_v4(), "");
+
+        assert!(matches!(
+            nonexistent_software_version_tag,
+            Err(diesel::result::Error::NotFound)
+        ));
+    }
+
+    #[test]
+    fn find_with_software_version_id() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tags = insert_test_software_version_tags(&conn);
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: Some(test_software_version_tags[2].software_version_id),
+            tag: None,
+            created_before: None,
+            created_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 1);
+        assert_eq!(
+            found_software_version_tags[0],
+            test_software_version_tags[2]
+        );
+    }
+
+    #[test]
+    fn find_with_tag() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tags = insert_test_software_version_tags(&conn);
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: None,
+            tag: Some(test_software_version_tags[2].tag.clone()),
+            created_before: None,
+            created_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 1);
+        assert_eq!(
+            found_software_version_tags[0],
+            test_software_version_tags[2]
+        );
+    }
+
+    #[test]
+    fn find_with_sort_and_limit_and_offset() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tags = insert_test_software_version_tags(&conn);
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: None,
+            tag: None,
+            created_before: None,
+            created_after: None,
+            sort: Some(String::from("desc(tag)")),
+            limit: Some(1),
+            offset: Some(0),
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 1);
+        assert_eq!(
+            found_software_version_tags[0],
+            test_software_version_tags[2]
+        );
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: None,
+            tag: None,
+            created_before: None,
+            created_after: None,
+            sort: Some(String::from("desc(tag)")),
+            limit: Some(1),
+            offset: Some(1),
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 1);
+        assert_eq!(
+            found_software_version_tags[0],
+            test_software_version_tags[1]
+        );
+    }
+
+    #[test]
+    fn find_with_created_before_and_created_after() {
+        let conn = get_test_db_connection();
+
+        insert_test_software_version_tags(&conn);
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: None,
+            tag: None,
+            created_before: None,
+            created_after: Some("2099-01-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 0);
+
+        let test_query = SoftwareVersionTagQuery {
+            software_version_id: None,
+            tag: None,
+            created_before: Some("2099-01-01T00:00:00".parse::<NaiveDateTime>().unwrap()),
+            created_after: None,
+            sort: None,
+            limit: None,
+            offset: None,
+        };
+
+        let found_software_version_tags = SoftwareVersionTagData::find(&conn, test_query)
+            .expect("Failed to find software_version_tags");
+
+        assert_eq!(found_software_version_tags.len(), 3);
+    }
+
+    #[test]
+    fn create_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tag = insert_test_software_version_tag(&conn);
+
+        assert_eq!(test_software_version_tag.tag, "test");
+    }
+
+    #[test]
+    fn create_failure_same_software_version_and_tag() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tag = insert_test_software_version_tag(&conn);
+
+        let copy_software_version_tag = NewSoftwareVersionTag {
+            software_version_id: test_software_version_tag.software_version_id,
+            tag: test_software_version_tag.tag,
+        };
+
+        let new_software_version_tag =
+            SoftwareVersionTagData::create(&conn, copy_software_version_tag);
+
+        assert!(matches!(
+            new_software_version_tag,
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            ),)
+        ));
+    }
+
+    #[test]
+    fn batch_create_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tags = insert_test_software_version_tags(&conn);
+
+        let mut expected_tags = HashSet::new();
+        expected_tags.insert(String::from("test1"));
+        expected_tags.insert(String::from("test2"));
+        expected_tags.insert(String::from("test3"));
+
+        let mut inserted_tags = HashSet::new();
+        for software_version_tag_data in test_software_version_tags {
+            inserted_tags.insert(software_version_tag_data.tag);
+        }
+
+        assert_eq!(expected_tags, inserted_tags);
+    }
+
+    #[test]
+    fn batch_create_failure_same_software_version_and_tag() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tags = insert_test_software_version_tags(&conn);
+
+        let copy_software_version_tag = NewSoftwareVersionTag {
+            software_version_id: test_software_version_tags[0].software_version_id,
+            tag: test_software_version_tags[0].tag.clone(),
+        };
+
+        let copy_software_version_tags = vec![copy_software_version_tag];
+
+        let new_software_version_tag =
+            SoftwareVersionTagData::batch_create(&conn, copy_software_version_tags);
+
+        assert!(matches!(
+            new_software_version_tag,
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            ),)
+        ));
+    }
+
+    #[test]
+    fn delete_by_software_version_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tag = insert_test_software_version_tag(&conn);
+
+        let delete_result = SoftwareVersionTagData::delete_by_software_version(
+            &conn,
+            test_software_version_tag.software_version_id,
+        )
+        .unwrap();
+
+        assert_eq!(delete_result, 1);
+
+        let test_software_version_tag2 = SoftwareVersionTagData::find_by_software_version_and_tag(
+            &conn,
+            test_software_version_tag.software_version_id,
+            &test_software_version_tag.tag,
+        );
+
+        assert!(matches!(
+            test_software_version_tag2,
+            Err(diesel::result::Error::NotFound)
+        ));
+    }
+
+    #[test]
+    fn delete_by_software_version_and_tag_success() {
+        let conn = get_test_db_connection();
+
+        let test_software_version_tag = insert_test_software_version_tag(&conn);
+
+        let delete_result = SoftwareVersionTagData::delete_by_software_version_and_tag(
+            &conn,
+            test_software_version_tag.software_version_id,
+            &test_software_version_tag.tag,
+        )
+        .unwrap();
+
+        assert_eq!(delete_result, 1);
+
+        let test_software_version_tag2 = SoftwareVersionTagData::find_by_software_version_and_tag(
+            &conn,
+            test_software_version_tag.software_version_id,
+            &test_software_version_tag.tag,
+        );
+
+        assert!(matches!(
+            test_software_version_tag2,
+            Err(diesel::result::Error::NotFound)
+        ));
+    }
+}

--- a/src/models/template.rs
+++ b/src/models/template.rs
@@ -135,7 +135,7 @@ impl TemplateData {
 
     /// Queries the DB for templates matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve templates matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve templates matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved templates as TemplateData
     /// instances or an error if the query fails for some reason
     pub fn find(

--- a/src/models/test.rs
+++ b/src/models/test.rs
@@ -132,7 +132,7 @@ impl TestData {
 
     /// Queries the DB for test matching the specified query criteria
     ///
-    /// Queries the DB using `conn` to retrieve tests matching the crieria in `params`
+    /// Queries the DB using `conn` to retrieve tests matching the criteria in `params`
     /// Returns a result containing either a vector of the retrieved tests as TestData
     /// instances or an error if the query fails for some reason
     pub fn find(

--- a/src/routes/error_handling.rs
+++ b/src/routes/error_handling.rs
@@ -19,12 +19,17 @@ pub struct ErrorBody {
 
 /// Creates and returns a generic error message HttpResponse that includes `error_message`
 pub fn default_500(error_message: &impl Display) -> HttpResponse {
-    HttpResponse::InternalServerError().json(ErrorBody {
+    HttpResponse::InternalServerError().json(default_500_body(error_message))
+}
+
+/// Creates and returns a generic error message body that includes `error_message`
+pub fn default_500_body(error_message: &impl Display) -> ErrorBody {
+    ErrorBody {
         title: "Server error".to_string(),
         status: 500,
         detail: format!(
             "Encountered the following error while trying to process your request: {}",
             error_message
         ),
-    })
+    }
 }

--- a/src/routes/run.rs
+++ b/src/routes/run.rs
@@ -405,6 +405,11 @@ async fn run_for_test(
                     title: "Server error".to_string(),
                     status: 500,
                     detail: format!("Error while attempting to retrieve WDL: {}", e)
+                },
+                test_runner::Error::Git(e) => ErrorBody {
+                    title: "Git error".to_string(),
+                    status: 500,
+                    detail: format!("Error while attempting to retrieve git repo information: {}", e)
                 }
             };
             HttpResponseBuilder::new(
@@ -1298,6 +1303,7 @@ mod tests {
             CromwellClient::new(Client::default(), &mockito::server_url()),
             TestResourceClient::new(Client::default(), None),
             None,
+            None,
         );
 
         let test_template = create_test_template(&pool.get().unwrap());
@@ -1393,6 +1399,7 @@ mod tests {
         let test_runner = TestRunner::new(
             CromwellClient::new(Client::default(), &mockito::server_url()),
             TestResourceClient::new(Client::default(), None),
+            None,
             None,
         );
 

--- a/src/routes/software_build.rs
+++ b/src/routes/software_build.rs
@@ -153,6 +153,7 @@ mod tests {
     use crate::models::software_version::{NewSoftwareVersion, SoftwareVersionData};
     use crate::unit_test_util::*;
     use actix_web::{http, test, App};
+    use chrono::NaiveDateTime;
     use diesel::PgConnection;
     use uuid::Uuid;
 
@@ -170,6 +171,7 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
         let new_software_version = SoftwareVersionData::create(conn, new_software_version).unwrap();

--- a/src/routes/software_version.rs
+++ b/src/routes/software_version.rs
@@ -4,12 +4,22 @@
 //! their URI mappings
 
 use crate::db;
-use crate::models::software_version::{SoftwareVersionData, SoftwareVersionQuery};
+use crate::manager::software_builder;
+use crate::models::software::SoftwareData;
+use crate::models::software_version::{
+    SoftwareVersionData, SoftwareVersionQuery, SoftwareVersionWithTagsData,
+};
 use crate::routes::disabled_features;
-use crate::routes::error_handling::{default_500, ErrorBody};
+use crate::routes::error_handling::{default_500, default_500_body, ErrorBody};
 use crate::routes::util::parse_id;
+use crate::util::git_repos;
+use crate::util::git_repos::GitRepoManager;
+use actix_web::http::StatusCode;
 use actix_web::{error::BlockingError, web, HttpRequest, HttpResponse};
+use chrono::NaiveDateTime;
+use diesel::PgConnection;
 use log::error;
+use uuid::Uuid;
 
 /// Handles requests to /software_versions/{id} for retrieving software_version info by software_version_id
 ///
@@ -19,7 +29,7 @@ use log::error;
 /// error occurs
 ///
 /// # Panics
-/// Panics if attempting to connect to the database software_versions in an error
+/// Panics if attempting to connect to the database results in an error
 async fn find_by_id(req: HttpRequest, pool: web::Data<db::DbPool>) -> HttpResponse {
     // Pull id param from path
     let id = &req.match_info().get("id").unwrap();
@@ -34,7 +44,7 @@ async fn find_by_id(req: HttpRequest, pool: web::Data<db::DbPool>) -> HttpRespon
     match web::block(move || {
         let conn = pool.get().expect("Failed to get DB connection from pool");
 
-        match SoftwareVersionData::find_by_id(&conn, id) {
+        match SoftwareVersionWithTagsData::find_by_id(&conn, id) {
             Ok(software_version) => Ok(software_version),
             Err(e) => {
                 error!("{}", e);
@@ -72,7 +82,7 @@ async fn find_by_id(req: HttpRequest, pool: web::Data<db::DbPool>) -> HttpRespon
 /// software_version or some other error occurs
 ///
 /// # Panics
-/// Panics if attempting to connect to the database software_versions in an error
+/// Panics if attempting to connect to the database results in an error
 async fn find(
     web::Query(query): web::Query<SoftwareVersionQuery>,
     pool: web::Data<db::DbPool>,
@@ -81,7 +91,7 @@ async fn find(
     match web::block(move || {
         let conn = pool.get().expect("Failed to get DB connection from pool");
 
-        match SoftwareVersionData::find(&conn, query) {
+        match SoftwareVersionWithTagsData::find(&conn, query) {
             Ok(software_version) => Ok(software_version),
             Err(e) => {
                 error!("{}", e);
@@ -112,6 +122,224 @@ async fn find(
     }
 }
 
+/// Handles requests to /software_versions/{id} for updating software_version info
+///
+/// This function is called by Actix-Web when a put request is made to the /software_versions/{id}
+/// mapping
+/// It parses the id from `req`, connects to the db via a connection from `pool`, and updates the
+/// the tags, commit, and commit_date for the software_version specified by id by using
+/// `git_repo_manager` check for those in the repo cache.  Returns a response with the updated
+/// software version if successful or an appropriate error message if it fails
+///
+/// # Panics
+/// Panics if attempting to connect to the database results in an error
+async fn update(
+    req: HttpRequest,
+    pool: web::Data<db::DbPool>,
+    git_repo_manager: web::Data<GitRepoManager>,
+) -> HttpResponse {
+    // Pull id param from path
+    let id = &req.match_info().get("id").unwrap();
+
+    // Parse ID into Uuid
+    let id = match parse_id(id) {
+        Ok(id) => id,
+        Err(error_response) => return error_response,
+    };
+    match web::block(move || {
+        let conn = pool.get().expect("Failed to get DB connection from pool");
+
+        update_software_version(id, &conn, &git_repo_manager)
+    })
+    .await
+    {
+        Ok(software_version) => HttpResponse::Ok().json(software_version),
+        Err(e) => match e {
+            BlockingError::Canceled => {
+                error!("{}", e);
+                default_500(&e)
+            }
+            BlockingError::Error(e_body) => {
+                error!("Encountered an error while attempting to update software version with id {} : {:?}", id, &e_body);
+                HttpResponse::build(
+                    StatusCode::from_u16(e_body.status)
+                        .expect("Failed to convert error body status to status code"),
+                )
+                .json(e_body)
+            }
+        },
+    }
+}
+
+/// Updates the tags, commit, and commit_date for the software version specified by
+/// `software_version_id` and returns an appropriate HttpResponse containing either the updated
+/// software_version or an error message if something fails
+fn update_software_version(
+    software_version_id: Uuid,
+    conn: &PgConnection,
+    git_repo_manager: &GitRepoManager,
+) -> Result<SoftwareVersionWithTagsData, ErrorBody> {
+    // Attempt to retrieve the software_version we want to update
+    let found_software_version: SoftwareVersionData =
+        get_software_version(conn, software_version_id)?;
+    // Get the commit, tags, and commit date for it
+    let (commit, tags, commit_date): (String, Vec<String>, NaiveDateTime) = match git_repo_manager
+        .get_commit_and_tags_and_date_from_commit_or_tag(
+            found_software_version.software_id,
+            &found_software_version.commit,
+        ) {
+        Ok(commit_and_tags_and_date) => commit_and_tags_and_date,
+        Err(git_repos::Error::IO(e)) => {
+            // If we get an IO NotFound error, that indicates we almost definitely haven't
+            // cloned the repo yet, so we'll clone and try again
+            if e.kind() == std::io::ErrorKind::NotFound {
+                cache_git_repo_for_software(
+                    conn,
+                    found_software_version.software_id,
+                    git_repo_manager,
+                )?;
+                match git_repo_manager.get_commit_and_tags_and_date_from_commit_or_tag(
+                    found_software_version.software_id,
+                    &found_software_version.commit,
+                ) {
+                    Ok(commit_and_tags_and_date) => commit_and_tags_and_date,
+                    Err(e) => return Err(default_500_body(&e)),
+                }
+            } else {
+                return Err(default_500_body(&e));
+            }
+        }
+        Err(e) => {
+            return Err(default_500_body(&e));
+        }
+    };
+    // Update the commit, commit date, and tags for the software_version
+    // Call in a transaction
+    #[cfg(not(test))]
+    let result = conn.build_transaction().run(|| {
+        software_builder::update_existing_software_version(
+            conn,
+            &found_software_version,
+            &commit,
+            &tags,
+            &commit_date,
+        )
+    });
+
+    // Tests do all database stuff in transactions that are not committed so they don't interfere
+    // with other tests. An unfortunate side effect of this is that we can't use transactions in
+    // the code being tested, because you can't have a transaction within a transaction.  So, for
+    // tests, we don't specify that this be run in a transaction.
+    #[cfg(test)]
+    let result = software_builder::update_existing_software_version(
+        conn,
+        &found_software_version,
+        &commit,
+        &tags,
+        &commit_date,
+    );
+
+    // If we succeeded, get the updated software version with tags.  Otherwise, return an error body
+    match result {
+        Ok(software_version) => {
+            match SoftwareVersionWithTagsData::find_by_id(conn, software_version.software_version_id) {
+                Ok(software_version_with_tags) => Ok(software_version_with_tags),
+                Err(e) => Err(ErrorBody {
+                    title: "Failed to get updated software version".to_string(),
+                    status: 500,
+                    detail: format!("Succeeded in updating software version but failed to return updated data due to error: {}", e),
+                })
+            }
+        }
+        Err(e) => {
+            error!(
+                "Encountered an error trying to update software_version {:?} : {}",
+                found_software_version, e
+            );
+            Err(ErrorBody {
+                title: "Failed to update software version".to_string(),
+                status: 500,
+                detail: format!("Failed to update software_version due to error: {}", e),
+            })
+        }
+    }
+}
+
+/// Attempts to retrieve software version record specified by `software_version_id`.  Returns the
+/// found record if successful or an appropriate error message if unsuccessful.
+fn get_software_version(
+    conn: &PgConnection,
+    software_version_id: Uuid,
+) -> Result<SoftwareVersionData, ErrorBody> {
+    match SoftwareVersionData::find_by_id(conn, software_version_id) {
+        Ok(software_version) => Ok(software_version),
+        Err(diesel::NotFound) => {
+            error!(
+                "Failed to retrieve software version with id {}",
+                software_version_id
+            );
+            return Err(ErrorBody {
+                title: "No software_version found".to_string(),
+                status: 404,
+                detail: "No software_version found with the specified ID".to_string(),
+            });
+        }
+        Err(e) => {
+            error!("{}", e);
+            return Err(ErrorBody {
+                title: "Failed to retrieve software version".to_string(),
+                status: 500,
+                detail: format!(
+                    "Failed to retrieve software_version to update due to error: {}",
+                    e
+                ),
+            });
+        }
+    }
+}
+
+/// Attempts to retrieve the software record specified by `software_id` and clone the repo for that
+/// software to the repo cache using `git_repo_manager`.  Returns an appropriate error message if it
+/// fails
+fn cache_git_repo_for_software(
+    conn: &PgConnection,
+    software_id: Uuid,
+    git_repo_manager: &GitRepoManager,
+) -> Result<(), ErrorBody> {
+    let software = match SoftwareData::find_by_id(conn, software_id) {
+        Ok(software) => software,
+        Err(diesel::NotFound) => {
+            error!(
+                "Failed to retrieve software for software_id {}",
+                software_id
+            );
+            return Err(ErrorBody {
+                title: "No software_version found".to_string(),
+                status: 404,
+                detail: "No software_version found with the specified ID".to_string(),
+            });
+        }
+        Err(e) => {
+            error!("Failed to retrieve software for downloading repo for software_version with software_id {} with error {}", software_id, e);
+            return Err(ErrorBody {
+                title: "Failed to retrieve software".to_string(),
+                status: 500,
+                detail: format!(
+                    "Failed to retrieve software when attempting to cache repo, with error: {}",
+                    e
+                ),
+            });
+        }
+    };
+    if let Err(e) =
+        git_repo_manager.download_git_repo(software.software_id, &software.repository_url)
+    {
+        return Err(default_500_body(&e));
+    }
+
+    Ok(())
+}
+
 /// Attaches the REST mappings in this file to a service config
 ///
 /// To be called when configuring the Actix-Web app service.  Registers the mappings in this file
@@ -128,7 +356,11 @@ pub fn init_routes(cfg: &mut web::ServiceConfig, enable_custom_image_builds: boo
 /// Attaches the REST mappings in this file to a service config for if software building
 /// functionality is enabled
 fn init_routes_software_building_enabled(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::resource("/software_versions/{id}").route(web::get().to(find_by_id)));
+    cfg.service(
+        web::resource("/software_versions/{id}")
+            .route(web::get().to(find_by_id))
+            .route(web::put().to(update)),
+    );
     cfg.service(web::resource("/software_versions").route(web::get().to(find)));
 }
 
@@ -150,12 +382,18 @@ mod tests {
     use crate::custom_sql_types::MachineTypeEnum;
     use crate::models::software::{NewSoftware, SoftwareData};
     use crate::models::software_version::NewSoftwareVersion;
+    use crate::models::software_version_tag::{
+        NewSoftwareVersionTag, SoftwareVersionTagData, SoftwareVersionTagQuery,
+    };
+    use crate::schema::software_version::commit;
     use crate::unit_test_util::*;
     use actix_web::{http, test, App};
+    use chrono::NaiveDateTime;
     use diesel::PgConnection;
+    use tempfile::TempDir;
     use uuid::Uuid;
 
-    fn create_test_software_version(conn: &PgConnection) -> SoftwareVersionData {
+    fn create_test_software_version(conn: &PgConnection) -> SoftwareVersionWithTagsData {
         let new_software = NewSoftware {
             name: String::from("Kevin's Software"),
             description: Some(String::from("Kevin made this software for testing")),
@@ -169,10 +407,29 @@ mod tests {
         let new_software_version = NewSoftwareVersion {
             software_id: new_software.software_id,
             commit: String::from("9aac5e85f34921b2642beded8b3891b97c5a6dc7"),
+            commit_date: "2021-06-01T00:00:00".parse::<NaiveDateTime>().unwrap(),
         };
 
-        SoftwareVersionData::create(conn, new_software_version)
-            .expect("Failed inserting test software_version")
+        let new_software_version = SoftwareVersionData::create(conn, new_software_version)
+            .expect("Failed inserting test software_version");
+
+        let new_software_version_tags = SoftwareVersionTagData::batch_create(
+            conn,
+            vec![
+                NewSoftwareVersionTag {
+                    software_version_id: new_software_version.software_version_id,
+                    tag: "tag1".to_string(),
+                },
+                NewSoftwareVersionTag {
+                    software_version_id: new_software_version.software_version_id,
+                    tag: "tag2".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+        SoftwareVersionWithTagsData::find_by_id(conn, new_software_version.software_version_id)
+            .unwrap()
     }
 
     #[actix_rt::test]
@@ -199,7 +456,8 @@ mod tests {
         assert_eq!(resp.status(), http::StatusCode::OK);
 
         let result = test::read_body(resp).await;
-        let test_software_version: SoftwareVersionData = serde_json::from_slice(&result).unwrap();
+        let test_software_version: SoftwareVersionWithTagsData =
+            serde_json::from_slice(&result).unwrap();
 
         assert_eq!(test_software_version, new_software_version);
     }
@@ -310,13 +568,13 @@ mod tests {
         let req = test::TestRequest::get()
             .uri("/software_versions?name=Kevin%27s%20SoftwareVersion")
             .to_request();
-        println!("{:?}", req);
+
         let resp = test::call_service(&mut app, req).await;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
 
         let result = test::read_body(resp).await;
-        let test_software_versions: Vec<SoftwareVersionData> =
+        let test_software_versions: Vec<SoftwareVersionWithTagsData> =
             serde_json::from_slice(&result).unwrap();
 
         assert_eq!(test_software_versions.len(), 1);
@@ -381,5 +639,111 @@ mod tests {
         assert_eq!(error_body.title, "Software building disabled");
         assert_eq!(error_body.status, 422);
         assert_eq!(error_body.detail, "You are trying to access a software-related endpoint, but the software building feature is disabled for this CARROT server");
+    }
+
+    #[actix_rt::test]
+    async fn update_success() {
+        let pool = get_test_db_pool();
+
+        let (test_repo, commit1, commit2, commit1_date, _) = get_test_remote_github_repo();
+
+        println!("commit1: {}, commit2: {}", commit1, commit2);
+
+        let new_software = NewSoftware {
+            name: String::from("Kevin's Software"),
+            description: Some(String::from("Kevin made this software for testing")),
+            repository_url: String::from(test_repo.to_str().unwrap()),
+            machine_type: Some(MachineTypeEnum::Standard),
+            created_by: Some(String::from("Kevin@example.com")),
+        };
+
+        let new_software = SoftwareData::create(&pool.get().unwrap(), new_software).unwrap();
+
+        let new_software_version = SoftwareVersionData::create(
+            &pool.get().unwrap(),
+            NewSoftwareVersion {
+                commit: String::from("first"),
+                software_id: new_software.software_id,
+                commit_date: NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+            },
+        )
+        .unwrap();
+
+        let repo_cache_temp_dir = TempDir::new().unwrap();
+        let git_repo_manager = GitRepoManager::new(
+            None,
+            repo_cache_temp_dir.path().to_str().unwrap().to_string(),
+        );
+
+        let mut app = test::init_service(
+            App::new()
+                .data(pool)
+                .data(git_repo_manager)
+                .configure(init_routes_software_building_enabled),
+        )
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri(&format!(
+                "/software_versions/{}",
+                new_software_version.software_version_id
+            ))
+            .to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        let result = test::read_body(resp).await;
+        let test_software_version: SoftwareVersionWithTagsData =
+            serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            test_software_version.software_version_id,
+            new_software_version.software_version_id
+        );
+        assert_eq!(test_software_version.commit, commit1);
+        assert_eq!(test_software_version.commit_date, commit1_date);
+
+        assert_eq!(test_software_version.tags.len(), 2);
+        assert!(test_software_version.tags.contains(&String::from("first")));
+        assert!(test_software_version
+            .tags
+            .contains(&String::from("beginning")));
+    }
+
+    #[actix_rt::test]
+    async fn update_failure_not_found() {
+        let pool = get_test_db_pool();
+
+        let repo_cache_temp_dir = TempDir::new().unwrap();
+        let git_repo_manager = GitRepoManager::new(
+            None,
+            repo_cache_temp_dir.path().to_str().unwrap().to_string(),
+        );
+
+        let mut app = test::init_service(
+            App::new()
+                .data(pool)
+                .data(git_repo_manager)
+                .configure(init_routes_software_building_enabled),
+        )
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri(&format!("/software_versions/{}", Uuid::new_v4()))
+            .to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+
+        let result = test::read_body(resp).await;
+        let error_body: ErrorBody = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(error_body.title, "No software_version found");
+        assert_eq!(error_body.status, 404);
+        assert_eq!(
+            error_body.detail,
+            "No software_version found with the specified ID"
+        );
     }
 }

--- a/src/routes/template.rs
+++ b/src/routes/template.rs
@@ -2525,9 +2525,6 @@ mod tests {
         let result = test::read_body(resp).await;
 
         let result_json: Value = serde_json::from_slice(&result).unwrap();
-
-        println!("Result: {}", result_json.to_string());
-
         let test_template: TemplateData = serde_json::from_slice(&result).unwrap();
 
         // Verify that what's returned is the template we expect

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -168,6 +168,30 @@ table! {
         software_version_id -> Uuid,
         software_id -> Uuid,
         commit -> Text,
+        commit_date -> Timestamptz,
+        created_at -> Timestamptz,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    software_version_tag(software_version_id, tag) {
+        software_version_id -> Uuid,
+        tag -> Text,
+        created_at -> Timestamptz,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    software_version_with_tags(software_version_id) {
+        software_version_id -> Uuid,
+        software_id -> Uuid,
+        commit -> Text,
+        commit_date -> Timestamptz,
+        tags -> Array<Text>,
         created_at -> Timestamptz,
     }
 }
@@ -320,6 +344,7 @@ table! {
 
 joinable!(test -> template(template_id));
 joinable!(software_version -> software(software_id));
+joinable!(software_version_tag -> software_version(software_version_id));
 
 allow_tables_to_appear_in_same_query!(
     pipeline,
@@ -332,6 +357,7 @@ allow_tables_to_appear_in_same_query!(
     run_with_results_and_errors,
     software,
     software_version,
+    software_version_tag,
     software_build,
     run_software_version,
     subscription,

--- a/src/unit_test_util.rs
+++ b/src/unit_test_util.rs
@@ -1,14 +1,27 @@
 //! Contains utility functions required by unit tests within the models module
 
 use crate::config;
-use crate::config::{Config, CromwellConfig, LocalWdlStorageConfig, WdlStorageConfig};
+use crate::config::{
+    Config, CromwellConfig, CustomImageBuildConfig, LocalWdlStorageConfig,
+    PrivateGithubAccessConfig, WdlStorageConfig,
+};
+use crate::custom_sql_types::MachineTypeEnum;
 use crate::db;
+use crate::manager::test_runner::TestRunner;
+use crate::models::software::{NewSoftware, SoftwareData};
+use crate::requests::cromwell_requests::CromwellClient;
+use crate::requests::test_resource_requests::TestResourceClient;
+use crate::util::git_repos::GitRepoManager;
+use actix_web::client::Client;
+use chrono::NaiveDateTime;
 use diesel::pg::PgConnection;
 use diesel::Connection;
 use dotenv;
 use std::env;
 use std::fs::read_to_string;
 use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Once;
 use tempfile::{NamedTempFile, TempDir};
 
@@ -16,6 +29,9 @@ embed_migrations!("migrations");
 
 lazy_static! {
     pub static ref WDL_TEMP_DIR: TempDir = TempDir::new().unwrap();
+    pub static ref GIT_TEMP_DIR: TempDir = TempDir::new().unwrap();
+    pub static ref TEMP_GIT_REPO: (TempDir, String, String, NaiveDateTime, NaiveDateTime) =
+        initialize_test_remote_git_repo();
 }
 
 // For creating DB schema only once before tests run
@@ -28,6 +44,39 @@ pub fn initialize_db_schema(conn: &PgConnection) {
             panic!("Database schema migrations failed with error: {}", e);
         }
     });
+}
+
+fn initialize_test_remote_git_repo() -> (TempDir, String, String, NaiveDateTime, NaiveDateTime) {
+    // Load script we'll run
+    let script = read_to_string("testdata/util/git_repo/create_test_repo.sh").unwrap();
+    // Create a temp dir for the repo
+    let repo_temp_dir = TempDir::new().unwrap();
+    // Run script for filling repo
+    let output = Command::new("sh")
+        .current_dir(repo_temp_dir.path())
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap();
+
+    let mut commits: Vec<String> = String::from_utf8_lossy(&*output.stdout)
+        .split_terminator("\n")
+        .map(String::from)
+        .collect();
+    let second_commit_date =
+        NaiveDateTime::parse_from_str(&commits.pop().unwrap(), "%a %b %-d %T %Y %z").unwrap();
+    let first_commit_date =
+        NaiveDateTime::parse_from_str(&commits.pop().unwrap(), "%a %b %-d %T %Y %z").unwrap();
+    let second_commit = commits.pop().unwrap();
+    let first_commit = commits.pop().unwrap();
+
+    (
+        repo_temp_dir,
+        first_commit,
+        second_commit,
+        first_commit_date,
+        second_commit_date,
+    )
 }
 
 pub fn get_test_db_connection() -> PgConnection {
@@ -64,6 +113,64 @@ pub fn get_test_db_pool() -> db::DbPool {
     conn
 }
 
+pub fn get_test_test_runner_building_enabled() -> TestRunner {
+    let config: Config = load_default_config();
+
+    let cromwell_client: CromwellClient =
+        CromwellClient::new(Client::default(), &mockito::server_url());
+    let test_resource_client: TestResourceClient = TestResourceClient::new(Client::default(), None);
+
+    let image_build_config: CustomImageBuildConfig =
+        config.custom_image_build().unwrap().to_owned();
+
+    let git_repo_manager: GitRepoManager = GitRepoManager::new(
+        image_build_config
+            .private_github_access()
+            .map(PrivateGithubAccessConfig::to_owned),
+        image_build_config.repo_cache_location().to_owned(),
+    );
+
+    TestRunner::new(
+        cromwell_client,
+        test_resource_client,
+        Some(image_build_config.image_registry_host()),
+        Some(git_repo_manager),
+    )
+}
+
+pub fn get_test_test_runner_building_disabled() -> TestRunner {
+    let cromwell_client: CromwellClient =
+        CromwellClient::new(Client::default(), &mockito::server_url());
+    let test_resource_client: TestResourceClient = TestResourceClient::new(Client::default(), None);
+
+    TestRunner::new(cromwell_client, test_resource_client, None, None)
+}
+
+/// Creates a git repo in `REMOTE_REPO_TEMP_DIR` with one file and two commits.  The first commit is
+/// tagged with 'first' and 'beginning'.  Returns a path to the repo and the two commit hashes
+/// along with the commit dates for each
+pub fn get_test_remote_github_repo() -> (PathBuf, String, String, NaiveDateTime, NaiveDateTime) {
+    (
+        TEMP_GIT_REPO.0.path().to_path_buf(),
+        TEMP_GIT_REPO.1.clone(),
+        TEMP_GIT_REPO.2.clone(),
+        TEMP_GIT_REPO.3.clone(),
+        TEMP_GIT_REPO.4.clone(),
+    )
+}
+
+pub fn insert_test_software_with_repo(conn: &PgConnection, repo_url: &str) -> SoftwareData {
+    let new_software = NewSoftware {
+        name: String::from("TestSoftware"),
+        description: Some(String::from("Kevin made this software for testing")),
+        repository_url: String::from(repo_url),
+        machine_type: Some(MachineTypeEnum::Standard),
+        created_by: Some(String::from("Kevin@example.com")),
+    };
+
+    SoftwareData::create(conn, new_software).unwrap()
+}
+
 pub fn load_default_config() -> Config {
     // Set up the WDL temp dir, since we can't load that from the test env file
     let wdl_storage_config = init_wdl_temp_dir();
@@ -76,6 +183,13 @@ pub fn load_default_config() -> Config {
         .expect("Failed to parse provided config file as a valid CARROT config");
     test_config.set_wdl_storage(wdl_storage_config);
     test_config.set_cromwell(cromwell_config);
+    if let Some(custom_image_build_config) = test_config.custom_image_build() {
+        test_config.set_custom_image_build(Some(CustomImageBuildConfig::new(
+            custom_image_build_config.image_registry_host().clone(),
+            custom_image_build_config.private_github_access().cloned(),
+            String::from(&*GIT_TEMP_DIR.path().to_str().unwrap()),
+        )));
+    }
 
     test_config
 }

--- a/src/util/git_repos.rs
+++ b/src/util/git_repos.rs
@@ -1,34 +1,279 @@
 //! Provides functions for doing operations related to git repos
 
 use crate::config::PrivateGithubAccessConfig;
+use chrono::NaiveDateTime;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{fmt, fs};
+use uuid::Uuid;
 
 /// Struct for checking the existence/accessibility of git repos
 #[derive(Clone)]
-pub struct GitRepoChecker {
+pub struct GitRepoManager {
     private_github_config: Option<PrivateGithubAccessConfig>,
+    repo_cache_location: String,
 }
 
-impl GitRepoChecker {
+#[derive(Debug)]
+pub enum Error {
+    IO(std::io::Error),
+    Git(String),
+    NotFound(String),
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::IO(e) => write!(f, "GitRepo Error IO {}", e),
+            Error::Git(e) => write!(f, "GitRepo Error Git {}", e),
+            Error::NotFound(e) => write!(f, "GitRepo Error NotFound commit or tag {}", e),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Error {
+        Error::IO(e)
+    }
+}
+
+impl GitRepoManager {
     /// Creates a new GitRepoChecker that will use private_github_config to access private github
     /// repos, if supplied
-    pub fn new(private_github_config: Option<PrivateGithubAccessConfig>) -> GitRepoChecker {
-        GitRepoChecker {
+    pub fn new(
+        private_github_config: Option<PrivateGithubAccessConfig>,
+        repo_cache_location: String,
+    ) -> GitRepoManager {
+        GitRepoManager {
             private_github_config,
+            repo_cache_location,
         }
     }
 
-    /// Checks where the remote git repo specified by `url` exists
-    ///
-    /// Uses the `git ls-remote` command to check the specified url for a git repo.  Returns Ok(true)
-    /// if the command is successful, and Ok(false) if it fails.  Returns an error if there is some
-    /// error trying to execute the command
-    pub fn git_repo_exists(&self, url: &str) -> Result<bool, std::io::Error> {
+    /// Attempts to download the git repo at `url` into the git repo cache at
+    /// `&self.repo_cache_location` in a new subdirectory `subdir`.  Returns an error if it fails
+    /// for any reason
+    pub fn download_git_repo(&self, software_id: Uuid, url: &str) -> Result<(), Error> {
         // Get the url with credentials if it's a github url and we have a configuration for private
         // github access
-        let url_to_check = if url.contains("github.com") {
+        let url_to_check = self.process_url_for_github_creds(url);
+        // Get the directory path we'll write to
+        let directory: PathBuf = [&self.repo_cache_location, &software_id.to_string()]
+            .iter()
+            .collect();
+        // Create the repo directory and subdir if they don't already exist
+        fs::create_dir_all(&directory)?;
+
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(format!("git clone -n {} {}", url_to_check, directory.to_str().expect("Failed to convert directory for git repo into string.  This should not happen.")))
+            .output()?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(Error::Git(
+                String::from_utf8_lossy(&*output.stderr).to_string(),
+            ))
+        }
+    }
+
+    /// Runs git fetch on the cached repo for the software specified by `software_id`, determines
+    /// whether `commit_or_tag` is a commit or tag, and if it is a commit, returns the commit and
+    /// the tags if the commit has any, and if it is a tag, returns the commit for that tag and any
+    /// tags for that commit.  If it's neither, returns Error::NotFound.  Returns an error for any
+    /// other failures
+    pub fn get_commit_and_tags_and_date_from_commit_or_tag(
+        &self,
+        software_id: Uuid,
+        commit_or_tag: &str,
+    ) -> Result<(String, Vec<String>, NaiveDateTime), Error> {
+        let subdir: String = software_id.to_string();
+        // Get the directory path for the git repo
+        let repo_dir: PathBuf = [&self.repo_cache_location, &subdir].iter().collect();
+        // Run git fetch on the repo so it's up to date
+        self.git_fetch(&repo_dir)?;
+        // Check first if it's a tag
+        let (commit, tags): (String, Vec<String>) =
+            if self.git_show_ref_verify(&repo_dir, commit_or_tag)? {
+                // Get the commit for this tag
+                let commit = self.git_rev_list(&repo_dir, commit_or_tag)?;
+                // Get all tags for this commit (in case there are multiple)
+                let tags = self.git_tag_points_at(&repo_dir, &commit)?;
+                (commit, tags)
+            }
+            // If it's not, we'll check if it's a commit
+            else if self.git_rev_parse_verify(&repo_dir, commit_or_tag)? {
+                // Check if we have a tag for this commit
+                let tags = self.git_tag_points_at(&repo_dir, commit_or_tag)?;
+                (commit_or_tag.to_owned(), tags)
+            }
+            // If it's neither, we'll return an error
+            else {
+                return Err(Error::NotFound(commit_or_tag.to_string()));
+            };
+
+        // Get the timestamp for the commit
+        let timestamp: NaiveDateTime = self.git_show_date(&repo_dir, &commit)?;
+
+        Ok((commit, tags, timestamp))
+    }
+
+    /// Runs git fetch on the git repo in `repo_dir`.  Returns an error if that fails
+    fn git_fetch(&self, repo_dir: &Path) -> Result<(), Error> {
+        // Run the command
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!("git fetch --tags -p -P"))
+            .output()?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(Error::Git(
+                String::from_utf8_lossy(&*output.stderr).to_string(),
+            ))
+        }
+    }
+
+    /// Runs git rev-parse on the git repo in `repo_dir` to see if `commit_maybe` is a commit in the
+    /// repo.  Returns true if it is an false if it's not.  If it fails for any other reason,
+    /// returns an error.  It should be noted that a true returned from this function does not
+    /// mean `commit_maybe` is not a tag.  This will also return true for tags.  If using this to
+    /// differentiate between tags and commits, `git_show_ref_verify` should be run first to check
+    /// if the string in question is a tag
+    fn git_rev_parse_verify(&self, repo_dir: &Path, commit_maybe: &str) -> Result<bool, Error> {
+        // Run the command
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!(
+                "git rev-parse --verify \"{}^{{commit}}\"",
+                commit_maybe
+            ))
+            .output()?;
+
+        // If the command was successful, return true
+        if output.status.success() {
+            Ok(true)
+        } else {
+            let stderr = String::from_utf8_lossy(&*output.stderr).to_string();
+            // If stderr matches the message that git spits out if the commit is not valid, return
+            // false
+            if stderr.trim() == "fatal: Needed a single revision" {
+                return Ok(false);
+            }
+            // Otherwise return an error
+            Err(Error::Git(stderr))
+        }
+    }
+
+    /// Uses git show-ref to verify whether `tag_maybe` is a tag.  Returns true if it is, or false
+    /// if it's not.  Returns an error if the command fails for some reason.
+    fn git_show_ref_verify(&self, repo_dir: &Path, tag_maybe: &str) -> Result<bool, Error> {
+        // Run the command
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!("git show-ref --verify \"refs/tags/{}\"", tag_maybe))
+            .output()?;
+
+        // If the command was successful, return true
+        if output.status.success() {
+            Ok(true)
+        } else {
+            let stderr = String::from_utf8_lossy(&*output.stderr).to_string();
+            // If stderr says it's not a valid ref, we'll just return false
+            if stderr.contains("- not a valid ref") {
+                return Ok(false);
+            }
+            // Otherwise return an error
+            Err(Error::Git(stderr))
+        }
+    }
+
+    /// Calls git rev-list on the repo in `repo_dir` for `tag` and returns the resulting commit if
+    /// successful, or an error if the command fails for some other reason
+    fn git_rev_list(&self, repo_dir: &Path, tag: &str) -> Result<String, Error> {
+        // Run the command
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!("git rev-list -n 1 {}", tag))
+            .output()?;
+
+        // If the command was successful, return the commit string
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&*output.stdout)
+                .to_string()
+                .trim()
+                .to_string())
+        } else {
+            // Otherwise return an error
+            Err(Error::Git(
+                String::from_utf8_lossy(&*output.stderr).to_string(),
+            ))
+        }
+    }
+
+    /// Calls git tag --points-at on the repo in `repo_dir` for `commit` and returns the resulting
+    /// tags if successful, or an error if the command fails for some other reason
+    fn git_tag_points_at(&self, repo_dir: &Path, commit: &str) -> Result<Vec<String>, Error> {
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!("git tag --points-at {}", commit))
+            .output()?;
+
+        if output.status.success() {
+            let stdout: String = String::from_utf8_lossy(&*output.stdout).to_string();
+            // Split the output on newlines to get the list of tags
+            Ok(stdout.split_terminator("\n").map(String::from).collect())
+        } else {
+            Err(Error::Git(
+                String::from_utf8_lossy(&*output.stderr).to_string(),
+            ))
+        }
+    }
+
+    /// Uses git show to get the commit date of `commit` and returns it as a NaiveDateTime if
+    /// found, otherwise returns an error
+    fn git_show_date(&self, repo_dir: &Path, commit: &str) -> Result<NaiveDateTime, Error> {
+        let output = Command::new("sh")
+            .current_dir(repo_dir)
+            .arg("-c")
+            .arg(format!(
+                "git show --no-patch --no-notes --pretty='%cd' {}",
+                commit
+            ))
+            .output()?;
+
+        if output.status.success() {
+            let stdout: String = String::from_utf8_lossy(&*output.stdout).trim().to_string();
+            // Attempt to parse the output as a datetime
+            Ok(
+                NaiveDateTime::parse_from_str(&stdout, "%a %b %-d %T %Y %z").expect(&format!(
+                    "Failed to parse timestamp {} for commit {}. This should not happen.",
+                    &stdout, commit
+                )),
+            )
+        } else {
+            Err(Error::Git(
+                String::from_utf8_lossy(&*output.stderr).to_string(),
+            ))
+        }
+    }
+
+    /// Checks if `url` is a github url.  If it is, and `&self` has credentials for connecting to
+    /// private github repos, adds those creds to the url and returns.  Otherwise, returns the url
+    /// unchanged as a String
+    fn process_url_for_github_creds(&self, url: &str) -> String {
+        if url.contains("github.com") {
             if let Some(private_github_config) = &self.private_github_config {
-                GitRepoChecker::format_github_url_with_creds(
+                GitRepoManager::format_github_url_with_creds(
                     url,
                     private_github_config.client_id(),
                     private_github_config.client_token(),
@@ -38,17 +283,6 @@ impl GitRepoChecker {
             }
         } else {
             url.to_string()
-        };
-
-        let output = Command::new("sh")
-            .arg("-c")
-            .arg(format!("git ls-remote {}", url_to_check))
-            .output()?;
-
-        if output.status.success() {
-            Ok(true)
-        } else {
-            Ok(false)
         }
     }
 
@@ -66,31 +300,144 @@ impl GitRepoChecker {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use std::env;
+    use std::fs::read_to_string;
+    use std::str::FromStr;
+    use tempfile::TempDir;
 
-    #[actix_rt::test]
-    async fn git_repo_exists_true() {
-        let git_repo_checker = GitRepoChecker::new(None);
-        let test = git_repo_checker
-            .git_repo_exists("https://github.com/broadinstitute/gatk.git")
-            .expect("Error when checking if git repo exists");
+    fn create_test_git_repo() -> (TempDir, String, String, NaiveDateTime, NaiveDateTime) {
+        // Create a tempdir we'll put the repo in
+        let temp_repo_dir = TempDir::new().unwrap();
+        // Make a dir for the repo
+        let mut repo_dir_path: PathBuf = temp_repo_dir.path().to_path_buf();
+        repo_dir_path.push(PathBuf::from_str("6d80625b-5044-4aad-8d21-5d648371b52a").unwrap());
+        fs::create_dir(&repo_dir_path).unwrap();
+        // Load script we'll run
+        let script = read_to_string("testdata/util/git_repo/create_test_repo.sh").unwrap();
+        // Run script for filling repo
+        let output = Command::new("sh")
+            .current_dir(repo_dir_path)
+            .arg("-c")
+            .arg(script)
+            .output()
+            .unwrap();
 
-        assert!(test);
+        let mut commits: Vec<String> = String::from_utf8_lossy(&*output.stdout)
+            .split_terminator("\n")
+            .map(String::from)
+            .collect();
+
+        let second_commit_date =
+            NaiveDateTime::parse_from_str(&commits.pop().unwrap(), "%a %b %-d %T %Y %z").unwrap();
+        let first_commit_date =
+            NaiveDateTime::parse_from_str(&commits.pop().unwrap(), "%a %b %-d %T %Y %z").unwrap();
+        let second_commit = commits.pop().unwrap();
+        let first_commit = commits.pop().unwrap();
+
+        (
+            temp_repo_dir,
+            first_commit,
+            second_commit,
+            first_commit_date,
+            second_commit_date,
+        )
     }
-    #[actix_rt::test]
-    async fn git_repo_exists_false() {
-        let git_repo_checker = GitRepoChecker::new(None);
-        let test = git_repo_checker
-            .git_repo_exists("https://example.com/example/project.git")
-            .expect("Error when checking if git repo exists");
 
-        assert!(!test);
+    #[actix_rt::test]
+    async fn get_commit_and_tags_from_commit_or_tag_success_commit() {
+        let (git_repo_temp_dir, first_commit, second_commit, first_date, second_date) =
+            create_test_git_repo();
+        let git_repo_manager =
+            GitRepoManager::new(None, git_repo_temp_dir.path().to_str().unwrap().to_string());
+        let (commit, tags, commit_date) = git_repo_manager
+            .get_commit_and_tags_and_date_from_commit_or_tag(
+                Uuid::from_str("6d80625b-5044-4aad-8d21-5d648371b52a").unwrap(),
+                &first_commit,
+            )
+            .expect("Error when checking for commit and tags");
+
+        assert_eq!(commit, first_commit);
+        assert_eq!(commit_date, first_date);
+        assert_eq!(tags.len(), 2);
+        assert!(tags.contains(&"first".to_string()));
+        assert!(tags.contains(&"beginning".to_string()));
+    }
+
+    #[actix_rt::test]
+    async fn get_commit_and_tags_from_commit_or_tag_success_commit_no_tags() {
+        let (git_repo_temp_dir, first_commit, second_commit, first_date, second_date) =
+            create_test_git_repo();
+        let git_repo_manager =
+            GitRepoManager::new(None, git_repo_temp_dir.path().to_str().unwrap().to_string());
+        let (commit, tags, commit_date) = git_repo_manager
+            .get_commit_and_tags_and_date_from_commit_or_tag(
+                Uuid::from_str("6d80625b-5044-4aad-8d21-5d648371b52a").unwrap(),
+                &second_commit,
+            )
+            .expect("Error when checking for commit and tags");
+
+        assert_eq!(commit, second_commit);
+        assert_eq!(commit_date, second_date);
+        assert_eq!(tags.len(), 0);
+    }
+
+    #[actix_rt::test]
+    async fn get_commit_and_tags_from_commit_or_tag_success_tag() {
+        let (git_repo_temp_dir, first_commit, second_commit, first_date, second_date) =
+            create_test_git_repo();
+        let git_repo_manager =
+            GitRepoManager::new(None, git_repo_temp_dir.path().to_str().unwrap().to_string());
+        let (commit, tags, commit_date) = git_repo_manager
+            .get_commit_and_tags_and_date_from_commit_or_tag(
+                Uuid::from_str("6d80625b-5044-4aad-8d21-5d648371b52a").unwrap(),
+                "first",
+            )
+            .expect("Error when checking for commit and tags");
+
+        assert_eq!(commit, first_commit);
+        assert_eq!(commit_date, first_date);
+        assert_eq!(tags.len(), 2);
+        assert!(tags.contains(&"first".to_string()));
+        assert!(tags.contains(&"beginning".to_string()));
+    }
+
+    #[actix_rt::test]
+    async fn get_commit_and_tags_from_commit_or_tag_failure_not_found() {
+        let (git_repo_temp_dir, first_commit, second_commit, first_date, second_date) =
+            create_test_git_repo();
+        let git_repo_manager =
+            GitRepoManager::new(None, git_repo_temp_dir.path().to_str().unwrap().to_string());
+        let commit_or_tag = String::from("last");
+        let error = git_repo_manager
+            .get_commit_and_tags_and_date_from_commit_or_tag(
+                Uuid::from_str("6d80625b-5044-4aad-8d21-5d648371b52a").unwrap(),
+                &commit_or_tag,
+            )
+            .expect_err("No error when checking for commit and tags");
+
+        assert!(matches!(error, Error::NotFound(commit_or_tag)));
+    }
+
+    #[actix_rt::test]
+    async fn get_commit_and_tags_from_commit_or_tag_failure_no_software() {
+        let (git_repo_temp_dir, first_commit, second_commit, first_date, second_date) =
+            create_test_git_repo();
+        let git_repo_manager =
+            GitRepoManager::new(None, git_repo_temp_dir.path().to_str().unwrap().to_string());
+        let error = git_repo_manager
+            .get_commit_and_tags_and_date_from_commit_or_tag(
+                Uuid::from_str("2d80625b-5044-4aad-8d21-5d648371b52a").unwrap(),
+                "first",
+            )
+            .expect_err("No error when checking for commit and tags");
+
+        assert!(matches!(error, Error::IO(_)));
     }
 
     #[test]
     fn format_github_url_with_creds_with_www() {
-        let test = GitRepoChecker::format_github_url_with_creds(
+        let test = GitRepoManager::format_github_url_with_creds(
             "https://www.example.com/example/project.git",
             "test_user",
             "test_pass",
@@ -104,7 +451,7 @@ mod tests {
 
     #[test]
     fn format_github_url_with_creds_without_www() {
-        let test = GitRepoChecker::format_github_url_with_creds(
+        let test = GitRepoManager::format_github_url_with_creds(
             "https://example.com/example/project.git",
             "test_user",
             "test_pass",
@@ -118,7 +465,7 @@ mod tests {
 
     #[test]
     fn format_github_url_with_creds_without_https() {
-        let test = GitRepoChecker::format_github_url_with_creds(
+        let test = GitRepoManager::format_github_url_with_creds(
             "example.com/example/project.git",
             "test_user",
             "test_pass",

--- a/src/util/run_csv.rs
+++ b/src/util/run_csv.rs
@@ -278,13 +278,11 @@ fn get_base_or_head_or_not_for_run(
     split.next();
     let commit: &str = match split.next() {
         Some(commit) => commit,
-        None => return String::new()
+        None => return String::new(),
     };
-    if commit == &github_info.head_commit
-    {
+    if commit == &github_info.head_commit {
         String::from("head")
-    } else if commit == &github_info.base_commit
-    {
+    } else if commit == &github_info.base_commit {
         String::from("base")
     } else {
         String::from("")

--- a/testdata/test_config.yml
+++ b/testdata/test_config.yml
@@ -8,7 +8,6 @@ cromwell:
   address: http://localhost:8000
 status_manager:
   status_check_wait_time_in_secs: 30
-  allowed_consecutive_status_check_failures: 1
 wdl_storage:
   local:
     wdl_location: ~/carrot/wdl

--- a/testdata/util/git_repo/create_test_repo.sh
+++ b/testdata/util/git_repo/create_test_repo.sh
@@ -1,0 +1,14 @@
+git init > /dev/null 2>&1
+touch file.txt
+echo "text" > file.txt
+git add file.txt > /dev/null 2>&1
+git commit -am "Initial commit" > /dev/null 2>&1
+first_commit_hash=$(git rev-parse HEAD)
+first_commit_date=$(git show --no-patch --no-notes --pretty='%cd' ${first_commit_hash})
+git tag "first" > /dev/null 2>&1
+git tag "beginning" > /dev/null 2>&1
+echo "more text" >> file.txt
+git commit -am "Arbitrary change" > /dev/null 2>&1
+second_commit_hash=$(git rev-parse HEAD)
+second_commit_date=$(git show --no-patch --no-notes --pretty='%cd' ${second_commit_hash})
+echo "${first_commit_hash}\n${second_commit_hash}\n${first_commit_date}\n${second_commit_date}"

--- a/testdata/util/git_repo/create_test_repo.sh
+++ b/testdata/util/git_repo/create_test_repo.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 git init > /dev/null 2>&1
 touch file.txt
 echo "text" > file.txt


### PR DESCRIPTION
Metadata-only clones of repos for software records will now be cached so that, when a build is triggered, the created software_version will have the commit for that build, and any tags will be put in a new software_version_tag table.

The `software_version_tag` table maps to `software_version` and keeps track of any tags mapped to the `commit` represented by that `software_version` record.  Any new `software_version` records created and any that are used with this change will have the `commit` column filled in with the commit hash, even if the user provided a tag.

The metadata-only clones of the repos are kept in a local dir that can be specified in the config file.  They are cloned when a new software record is created, or, if the record existed before this change, they will be cloned when next a custom build from that software is triggered.

Added a `commit_date` column to the `software_version` table which tracks the date the commit was made.  Data in the DB already is filled in by default with 1970-01-01.  Tags and commit date for a software_version can be updated using the new `carrot_cli software version update {software_version_id}` command.

Any requests to the software_version mappings on the REST API now also return a field called `tags` which has an array of any tags for that version.