### PR TITLE
Removed the status manager failure limit because it was just causing problems

### DIFF
--- a/carrot.example.yml
+++ b/carrot.example.yml
@@ -16,8 +16,6 @@ status_manager:
   # Optional time, in seconds, to wait between updating statuses of running tests
   # Defaults to 5 minutes if not specified
   status_check_wait_time_in_secs: 300
-  # Optional number of consecutive failures to allow when checking run/build statuses before terminating, defaults to 5
-  allowed_consecutive_status_check_failures: 5
 # Where to store WDLs either locally or in gcs (defaults to local with /carrot/wdl for the location)
 wdl_storage:
   # Use local if you want to store in a local directory

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,25 +270,17 @@ pub struct StatusManagerConfig {
     /// Time to wait between status check queries, or default to 5 minutes
     #[serde(default = "status_check_wait_time_in_secs_default")]
     status_check_wait_time_in_secs: u64,
-    /// Number of consecutive status check failures to allow before panicking, or default to 5
-    #[serde(default = "allowed_consecutive_status_check_failures_default")]
-    allowed_consecutive_status_check_failures: u32,
 }
 
 // Functions for providing the default values
 fn status_check_wait_time_in_secs_default() -> u64 {
     300
 }
-fn allowed_consecutive_status_check_failures_default() -> u32 {
-    5
-}
 
 impl Default for StatusManagerConfig {
     fn default() -> Self {
         StatusManagerConfig {
             status_check_wait_time_in_secs: status_check_wait_time_in_secs_default(),
-            allowed_consecutive_status_check_failures:
-                allowed_consecutive_status_check_failures_default(),
         }
     }
 }
@@ -296,18 +288,13 @@ impl Default for StatusManagerConfig {
 impl StatusManagerConfig {
     pub fn new(
         status_check_wait_time_in_secs: u64,
-        allowed_consecutive_status_check_failures: u32,
     ) -> Self {
         StatusManagerConfig {
             status_check_wait_time_in_secs,
-            allowed_consecutive_status_check_failures,
         }
     }
     pub fn status_check_wait_time_in_secs(&self) -> u64 {
         self.status_check_wait_time_in_secs
-    }
-    pub fn allowed_consecutive_status_check_failures(&self) -> u32 {
-        self.allowed_consecutive_status_check_failures
     }
 }
 


### PR DESCRIPTION
The status manager failure limit was intended as a way for folks running carrot to notice if there was an issue, but it is too likely for it encounter small transient errors (cromwell servers being overloaded or going down temporarily, for example) and to cause larger problems that go unnoticed because it does not properly shut down or just wait for the transient error to pass.