### PR TITLE
Added support for any valid ref (I think) for custom image builds

### DIFF
--- a/src/manager/test_runner.rs
+++ b/src/manager/test_runner.rs
@@ -563,7 +563,7 @@ impl TestRunner {
                     };
                 // Get commit, tags, and commit date from commit_or_tag
                 let (commit, tags, commit_date): (String, Vec<String>, NaiveDateTime) =
-                    match git_repo_manager.get_commit_and_tags_and_date_from_commit_or_tag(
+                    match git_repo_manager.get_commit_and_tags_and_date_from_ref(
                         software.software_id,
                         name_and_commit_or_tag[1],
                     ) {
@@ -576,7 +576,7 @@ impl TestRunner {
                                     software.software_id,
                                     &software.repository_url,
                                 )?;
-                                git_repo_manager.get_commit_and_tags_and_date_from_commit_or_tag(
+                                git_repo_manager.get_commit_and_tags_and_date_from_ref(
                                     software.software_id,
                                     name_and_commit_or_tag[1],
                                 )?

--- a/src/routes/software_version.rs
+++ b/src/routes/software_version.rs
@@ -184,7 +184,7 @@ fn update_software_version(
         get_software_version(conn, software_version_id)?;
     // Get the commit, tags, and commit date for it
     let (commit, tags, commit_date): (String, Vec<String>, NaiveDateTime) = match git_repo_manager
-        .get_commit_and_tags_and_date_from_commit_or_tag(
+        .get_commit_and_tags_and_date_from_ref(
             found_software_version.software_id,
             &found_software_version.commit,
         ) {
@@ -198,7 +198,7 @@ fn update_software_version(
                     found_software_version.software_id,
                     git_repo_manager,
                 )?;
-                match git_repo_manager.get_commit_and_tags_and_date_from_commit_or_tag(
+                match git_repo_manager.get_commit_and_tags_and_date_from_ref(
                     found_software_version.software_id,
                     &found_software_version.commit,
                 ) {

--- a/src/util/git_repos.rs
+++ b/src/util/git_repos.rs
@@ -105,7 +105,7 @@ impl GitRepoManager {
 
     /// Runs git fetch on the cached repo for the software specified by `software_id`, determines
     /// the commit hash for `git_ref`, and gets any tags for that commit along with the commit date.
-    /// Returns the commit hash, tags, and commit date.  If `git_ref` not a valid git ref, returns
+    /// Returns the commit hash, tags, and commit date.  If `git_ref` is not a valid git ref, returns
     /// Error::NotFound.  Returns an error for any other failures
     pub fn get_commit_and_tags_and_date_from_ref(
         &self,

--- a/testdata/util/git_repo/create_test_repo.sh
+++ b/testdata/util/git_repo/create_test_repo.sh
@@ -9,6 +9,7 @@ first_commit_hash=$(git rev-parse HEAD)
 first_commit_date=$(git show --no-patch --no-notes --pretty='%cd' ${first_commit_hash})
 git tag "first" > /dev/null 2>&1
 git tag "beginning" > /dev/null 2>&1
+git checkout -b "test_branch"
 echo "more text" >> file.txt
 git commit -am "Arbitrary change" > /dev/null 2>&1
 second_commit_hash=$(git rev-parse HEAD)


### PR DESCRIPTION
Previously, certain valid git refs - such as short hashes, branches, etc. - supplied as versions for custom image build inputs (e.g. `"image_build:carrot|188e101"`) would cause issues but not necessarily immediately error out.  Now, in the case that those are supplied, it will get the full commit hash for it, and store that and the tags (like it would for a tag or full commit hash previously).

Fixes #267 